### PR TITLE
Adds a memory sampler

### DIFF
--- a/lib/scout_apm/instruments/samplers/memory.ex
+++ b/lib/scout_apm/instruments/samplers/memory.ex
@@ -1,23 +1,8 @@
 defmodule ScoutApm.Instruments.Samplers.Memory do
   def metrics do
-    value = as_duration()
     [
-      %ScoutApm.Internal.Metric{
-        type: "Memory",
-        name: "Physical",
-        call_count: 1,
-        total_time: value,
-        exclusive_time: value,
-        min_time: value,
-        max_time: value,
-      }
+      ScoutApm.Internal.Metric.from_sampler_value("Memory", "Physical", total_mb())
     ]
-  end
-
-  # Hacky right now...we are really only handling timing metrics. This basically sends up the value in MB
-  # exactly as collected with no units conversion. Server-side, we expect memory to be in MB.
-  def as_duration do
-    ScoutApm.Internal.Duration.new(total_mb(), :seconds)
   end
 
   def total_bytes do

--- a/lib/scout_apm/instruments/samplers/memory.ex
+++ b/lib/scout_apm/instruments/samplers/memory.ex
@@ -1,0 +1,30 @@
+defmodule ScoutApm.Instruments.Samplers.Memory do
+  def metrics do
+    value = as_duration()
+    [
+      %ScoutApm.Internal.Metric{
+        type: "Memory",
+        name: "Physical",
+        call_count: 1,
+        total_time: value,
+        exclusive_time: value,
+        min_time: value,
+        max_time: value,
+      }
+    ]
+  end
+
+  # Hacky right now...we are really only handling timing metrics. This basically sends up the value in MB
+  # exactly as collected with no units conversion. Server-side, we expect memory to be in MB.
+  def as_duration do
+    ScoutApm.Internal.Duration.new(total_mb(), :seconds)
+  end
+
+  def total_bytes do
+    :erlang.memory(:total)
+  end
+
+  def total_mb do
+    total_bytes() / 1024.0 / 1024.0
+  end
+end

--- a/lib/scout_apm/internal/metric.ex
+++ b/lib/scout_apm/internal/metric.ex
@@ -25,7 +25,7 @@ defmodule ScoutApm.Internal.Metric do
     :type,
     :name,
 
-    # scope should be a 
+    # scope should be a
     :scope,
 
     :call_count,
@@ -79,6 +79,22 @@ defmodule ScoutApm.Internal.Metric do
       min_time: total_time,
       max_time: total_time,
       backtrace: layer.backtrace,
+    }
+  end
+
+  # Creates a metric with +type+, +name+, and +number+. +number+ is reported as-is in the payload w/o any unit conversion.
+  def from_sampler_value(type, name, number) do
+    duration = ScoutApm.Internal.Duration.new(number, :seconds) # ensures +number+ is reported as-is.
+
+    %__MODULE__{
+      type: type,
+      name: name,
+
+      call_count: 1,
+      total_time: duration,
+      exclusive_time: duration,
+      min_time: duration,
+      max_time: duration,
     }
   end
 


### PR DESCRIPTION
This reports the total memory used with every reporting period. A side result: we'll get some metrics even if an app isn't handling throughput. 

Without that, an app can appear as not reporting.