### PR TITLE
Ability to record a description via `Tracing.track`

### DIFF
--- a/lib/scout_apm/instruments/ecto_logger.ex
+++ b/lib/scout_apm/instruments/ecto_logger.ex
@@ -10,10 +10,10 @@ defmodule ScoutApm.Instruments.EctoLogger do
     # queue_time: 36000,
     # result: {:ok,
     #    %Postgrex.Result{
-    #      columns: ["id", "name", "age"], 
+    #      columns: ["id", "name", "age"],
     #      command: :select,
     #      connection_id: 70629,
-    #      num_rows: 1, 
+    #      num_rows: 1,
     #      rows: [[%TestappPhoenix.User{__meta__: #Ecto.Schema.Metadata<:loaded, "users">, age: 32, id: 1, name: "chris"}]]}
    #      },
     # source: "users"}
@@ -27,10 +27,7 @@ defmodule ScoutApm.Instruments.EctoLogger do
       "Ecto",
       query_name(entry),
       query_time(entry),
-      fn layer ->
-        layer
-        |> ScoutApm.Internal.Layer.update_desc(entry.query)
-      end
+      desc: entry.query
     )
   end
 

--- a/lib/scout_apm/internal/layer.ex
+++ b/lib/scout_apm/internal/layer.ex
@@ -1,4 +1,5 @@
 defmodule ScoutApm.Internal.Layer do
+
   @type t :: %__MODULE__{
     type: String.t,
     name: nil | String.t,
@@ -80,6 +81,21 @@ defmodule ScoutApm.Internal.Layer do
   def set_manual_duration(layer, %Duration{}=duration) do
     %{layer | manual_duration: duration}
   end
+
+  ##################
+  #  Update Fields #
+  ##################
+
+  # Updates Layer fields in bulk. See `update_field` functions for fields that permit updates.
+  def update_fields(layer,[]), do: layer
+  def update_fields(layer,fields) do
+    Enum.reduce(fields, layer, fn {key, value}, layer ->
+      update_field(layer, key, value)
+    end)
+  end
+
+  defp update_field(layer, :desc, value), do: update_desc(layer, value)
+  defp update_field(layer, :backtrace, value), do: update_backtrace(layer, value)
 
   #############
   #  Queries  #

--- a/lib/scout_apm/tracing.ex
+++ b/lib/scout_apm/tracing.ex
@@ -68,7 +68,12 @@ defmodule ScoutApm.Tracing do
 
   ## Example Usage
 
-      track("HTTP", "get", 300, :milliseconds)
+      track("Images", "resize", 200, :milliseconds)
+      track("HTTP", "get", 300, :milliseconds, desc: "HTTP GET http://api.github.com/")
+
+  ## Opts
+
+  A `desc` may be provided to add a detailed background of the event. These are viewable when accessing a trace in the UI.
 
   ## The duration must have actually occured
 
@@ -77,13 +82,13 @@ defmodule ScoutApm.Tracing do
 
     This naturally occurs when taking the output of Ecto log entries.
   """
-  @spec track(String.t, String.t, number(), Duration.unit) :: :ok | :error
-  def track(type, name, value, units) when is_number(value) do
+  @spec track(String.t, String.t, number(), Duration.unit, List.t) :: :ok | :error
+  def track(type, name, value, units, opts \\ []) when is_number(value) do
     if value < 0 do
       :error
     else
       duration = Duration.new(value, units)
-      TrackedRequest.track_layer(type, name, duration)
+      TrackedRequest.track_layer(type, name, duration, opts)
       :ok
     end
   end

--- a/lib/scout_apm/tracked_request.ex
+++ b/lib/scout_apm/tracked_request.ex
@@ -117,7 +117,7 @@ defmodule ScoutApm.TrackedRequest do
 
   def change_collector_fn(f), do: lookup() |> change_collector_fn(f) |> save()
   def change_collector_fn(%__MODULE__{} = tr, f) do
-    %{tr | collector_fn = build_collector_fn(f)}
+    %{tr | collector_fn: build_collector_fn(f)}
   end
 
   defp lookup() do

--- a/lib/scout_apm/tracked_request.ex
+++ b/lib/scout_apm/tracked_request.ex
@@ -69,18 +69,18 @@ defmodule ScoutApm.TrackedRequest do
     tr2
   end
 
-  def track_layer(%__MODULE__{} = tr, type, name, duration, callback) do
+  def track_layer(%__MODULE__{} = tr, type, name, duration, fields, callback) do
     layer =
       Layer.new(%{type: type, name: name})
       |> Layer.update_stopped_at
       |> Layer.set_manual_duration(duration)
+      |> Layer.update_fields(fields)
       |> callback.()
 
     record_child_of_current_layer(tr, layer)
   end
-
-  def track_layer(type, name, duration, callback \\ (fn x -> x end)) do
-    with_saved_tracked_request(fn tr -> track_layer(tr, type, name, duration, callback) end)
+  def track_layer(type, name, duration, fields, callback \\ (fn x -> x end)) do
+    with_saved_tracked_request(fn tr -> track_layer(tr, type, name, duration, fields, callback) end)
   end
 
   @doc """


### PR DESCRIPTION
IE: 

      track("HTTP", "get", 300, :milliseconds, desc: "HTTP GET http://api.github.com/")

Also adjusted `TrackedRequest.track_layer` to account for the new `fields` param.