### PR TITLE
Nested scopes

### DIFF
--- a/lib/scout_apm/instruments/eex_engine.ex
+++ b/lib/scout_apm/instruments/eex_engine.ex
@@ -1,6 +1,8 @@
 defmodule ScoutApm.Instruments.EExEngine do
   @behaviour Phoenix.Template.Engine
 
+  require Logger
+
   # TODO: Make this name correctly for other template locations
   # Currently it assumes too much about being located under `web/templates`
   def compile(path, name) do

--- a/lib/scout_apm/instruments/eex_engine.ex
+++ b/lib/scout_apm/instruments/eex_engine.ex
@@ -2,16 +2,23 @@ defmodule ScoutApm.Instruments.EExEngine do
   @behaviour Phoenix.Template.Engine
 
   # TODO: Make this name correctly for other template locations
+  # Currently it assumes too much about being located under `web/templates`
   def compile(path, name) do
     scout_name = path                  # web/templates/page/index.html.eex
                   |> String.split("/") # [web, templates, page, index.html.eex]
                   |> Enum.drop(2)      # [page, index.html.eex]
                   |> Enum.join("/")    # "page/index.html.eex"
 
+    # Since we only have a single layer of nesting currently, and
+    # practically every template will be "under" a layout, don't let the
+    # layout become the scope. Once we have deeper nesting, we'll want
+    # to allow layouts as scopable layers.
+    is_layout = String.starts_with?(scout_name, "layout")
+
     quoted_template = Phoenix.Template.EExEngine.compile(path, name)
 
     quote do
-      ScoutApm.Tracing.instrument("EEx", unquote(scout_name), fn -> unquote(quoted_template) end)
+      ScoutApm.Tracing.instrument("EEx", unquote(scout_name), [scopable: !unquote(is_layout)], fn -> unquote(quoted_template) end)
     end
   end
 end

--- a/lib/scout_apm/internal/layer.ex
+++ b/lib/scout_apm/internal/layer.ex
@@ -45,7 +45,7 @@ defmodule ScoutApm.Internal.Layer do
   def new(%{type: type, opts: opts} = data) do
     started_at = data[:started_at] || System.monotonic_time(:microseconds)
     name = data[:name]
-    scopable = Keyword.get(opts, :scopable)
+    scopable = Keyword.get(opts, :scopable, true)
 
     %__MODULE__{
       type: type,

--- a/lib/scout_apm/scope_stack.ex
+++ b/lib/scout_apm/scope_stack.ex
@@ -1,4 +1,14 @@
 defmodule ScoutApm.ScopeStack do
+  @moduledoc """
+  Internal to ScoutApm agent.
+
+  Used as a helper to track the current scope a layer is under, as we
+  build up a trace.
+
+  This doesn't have any way to pop, since it's used in a recursive call,
+  and coppies should just be tossed as the call stack finishes
+  """
+
   alias ScoutApm.Internal.Layer
 
   @max_depth 2

--- a/lib/scout_apm/scope_stack.ex
+++ b/lib/scout_apm/scope_stack.ex
@@ -1,0 +1,26 @@
+defmodule ScoutApm.ScopeStack do
+  alias ScoutApm.Internal.Layer
+
+  @max_depth 2
+
+  def new() do
+    []
+  end
+
+  def push_scope(stack, %Layer{scopable: false}), do: stack
+  def push_scope(stack, %Layer{} = layer), do: push_scope(stack, layer_to_scope(layer))
+  def push_scope(stack, %{} = scope) do
+    if Enum.count(stack) >= @max_depth do
+      stack
+    else
+      [scope | stack]
+    end
+  end
+
+  def layer_to_scope(%Layer{} = layer) do
+    %{type: layer.type, name: layer.name}
+  end
+
+  def current_scope([scope | _]), do: scope
+  def current_scope([]), do: nil
+end

--- a/lib/scout_apm/tracing.ex
+++ b/lib/scout_apm/tracing.ex
@@ -31,9 +31,9 @@ defmodule ScoutApm.Tracing do
           render conn, "index.html"
         end
   """
-  @spec instrument(String.t, String.t, function) :: any
-  def instrument(type, name, function) when is_function(function) do
-    TrackedRequest.start_layer(type, name)
+  @spec instrument(String.t, String.t, any, function) :: any
+  def instrument(type, name, opts \\ [], function) when is_function(function) do
+    TrackedRequest.start_layer(type, name, opts)
     result = function.()
     TrackedRequest.stop_layer()
     result

--- a/lib/scout_apm/tracked_request.ex
+++ b/lib/scout_apm/tracked_request.ex
@@ -28,8 +28,8 @@ defmodule ScoutApm.TrackedRequest do
   #  Interface  #
   ###############
 
-  def start_layer(%__MODULE__{} = tr, type, name) do
-    layer = Layer.new(%{type: type, name: name})
+  def start_layer(%__MODULE__{} = tr, type, name, opts \\ []) do
+    layer = Layer.new(%{type: type, name: name, opts: opts})
     push_layer(tr, layer)
   end
 

--- a/lib/scout_apm/tracked_request.ex
+++ b/lib/scout_apm/tracked_request.ex
@@ -28,13 +28,13 @@ defmodule ScoutApm.TrackedRequest do
   #  Interface  #
   ###############
 
-  def start_layer(%__MODULE__{} = tr, type, name, opts \\ []) do
-    layer = Layer.new(%{type: type, name: name, opts: opts})
+  def start_layer(%__MODULE__{} = tr, type, name, opts) do
+    layer = Layer.new(%{type: type, name: name, opts: opts || []})
     push_layer(tr, layer)
   end
 
-  def start_layer(type, name \\ nil) do
-    with_saved_tracked_request(fn tr -> start_layer(tr, type, name) end)
+  def start_layer(type, name, opts \\ []) do
+    with_saved_tracked_request(fn tr -> start_layer(tr, type, name, opts) end)
   end
 
   def stop_layer() do
@@ -72,7 +72,7 @@ defmodule ScoutApm.TrackedRequest do
 
   def track_layer(%__MODULE__{} = tr, type, name, duration, fields, callback) do
     layer =
-      Layer.new(%{type: type, name: name})
+      Layer.new(%{type: type, name: name, opts: []})
       |> Layer.update_stopped_at
       |> Layer.set_manual_duration(duration)
       |> Layer.update_fields(fields)
@@ -85,7 +85,7 @@ defmodule ScoutApm.TrackedRequest do
   end
 
   def record_context(%__MODULE__{} = tr, %ScoutApm.Internal.Context{} = context),
-    do: %{tr | contexts: [context | tr.contexts] }
+    do: %{tr | contexts: [context | tr.contexts]}
   def record_context(%ScoutApm.Internal.Context{} = context),
     do: with_saved_tracked_request(fn tr -> record_context(tr, context) end)
 


### PR DESCRIPTION
Enables nesting of layers inside of traces.

For instance:

![pagecontroller_index](https://cloud.githubusercontent.com/assets/6119/25717529/f67ec24e-30bf-11e7-8bab-14e073cda7d5.png)

Currently APM only supports a single layer of nesting, so view partials inside of view partials will get flattened out. This will likely be extended to deeper nesting in the future. 