### PR TITLE
App server load

### DIFF
--- a/lib/scout_apm/application.ex
+++ b/lib/scout_apm/application.ex
@@ -13,12 +13,15 @@ defmodule ScoutApm.Application do
     Logger.info("Starting ScoutAPM")
     children = [
       worker(ScoutApm.Store, []),
-      worker(ScoutApm.Config, []),
-      worker(ScoutApm.PersistentHistogram, []),
-      # worker(ScoutApm.ApplicationLoadNotification, [restart: :transient])
       worker(ScoutApm.Watcher, [ScoutApm.Store], id: :store_watcher),
+
+      worker(ScoutApm.Config, []),
       worker(ScoutApm.Watcher, [ScoutApm.Config], id: :config_watcher),
+
+      worker(ScoutApm.PersistentHistogram, []),
       worker(ScoutApm.Watcher, [ScoutApm.PersistentHistogram], id: :histogram_watcher),
+
+      worker(ScoutApm.ApplicationLoadNotification, [], [restart: :temporary])
     ]
 
     # Stupidly persistent. Really high max restarts for debugging

--- a/lib/scout_apm/application_load_notification.ex
+++ b/lib/scout_apm/application_load_notification.ex
@@ -1,0 +1,132 @@
+defmodule ScoutApm.ApplicationLoadNotification do
+  use GenServer
+  require Logger
+
+  @name __MODULE__
+
+  # Milliseconds
+  @wait_between_retries 10_000
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, :ok, [name: @name])
+  end
+
+  ################
+  #  Public API  #
+  ################
+  def init(:ok) do
+    initial_state = %{}
+    run([retries: 3])
+
+    {:ok, initial_state}
+  end
+
+  def run([retries: retries]) do
+    GenServer.cast(@name, {:run, [retries: retries]})
+  end
+
+  ###############
+  #  Callbacks  #
+  ###############
+
+  def handle_cast({:run, [retries: retries]}, state) do
+    payload =
+      ScoutApm.Payload.AppServerLoad.new()
+      |> Poison.encode!
+
+    # post/1 logs errors and successes, so only log if we stop retrying
+    case report(payload) do
+      :ok ->
+        {:stop, :normal, state}
+      :error ->
+        if retries < 1 do
+          Logger.info("Failed to send AppServerLoad, aborting.")
+          {:stop, :normal, state}
+        else
+          :timer.sleep(@wait_between_retries)
+          run([retries: retries - 1])
+          {:noreply, state}
+        end
+    end
+  end
+
+  # TODO: Refactor posting logic to recombine this w/ Reporter
+  @success_http_codes 200..299
+  @error_http_codes 400..499
+
+  defp report(encoded_payload) do
+    monitor = ScoutApm.Config.find(:monitor)
+    key = ScoutApm.Config.find(:key)
+
+    case {monitor, key} do
+      {nil, nil} ->
+        Logger.debug("Skipping AppServerLoad, both monitor and key settings are missing")
+        :ok
+
+      {true, nil} ->
+        Logger.debug("Skipping AppServerLoad, key is nil")
+        :ok
+
+      {true, ""} ->
+        Logger.debug("Skipping AppServerLoad, key is empty")
+        :ok
+
+      {nil, _} ->
+        Logger.debug("Skipping AppServerLoad, monitor is nil")
+        :ok
+
+      {false, _} ->
+        Logger.debug("Skipping AppServerLoad, monitor is false")
+        :ok
+
+      _ ->
+        post(encoded_payload)
+    end
+  end
+
+  defp post(encoded_payload) do
+    host = ScoutApm.Config.find(:host)
+    name = ScoutApm.Config.find(:name)
+    key = ScoutApm.Config.find(:key)
+
+    method = :post
+    query = URI.encode_query(%{"key" => key, "name" => name})
+    url = <<"#{host}/apps/app_server_load.scout?#{query}">>
+    options = []
+    header_list = headers()
+
+    case :hackney.request(method, url, header_list , encoded_payload, options) do
+      {:ok, status_code, _resp_headers, _client_ref} when status_code in @success_http_codes ->
+        Logger.info("AppServerLoad Report Succeeded. Status: #{inspect status_code}")
+        :ok
+
+      {:ok, status_code, resp_headers, _client_ref} when status_code in @error_http_codes ->
+        Logger.info("AppServerLoad Report Failed with #{status_code}. Response Headers: #{inspect resp_headers}")
+        :error
+
+      {:ok, status_code, _resp_headers, _client_ref} ->
+        Logger.info("AppServerLoad Report Unexpected Status: #{inspect status_code}")
+        :error
+
+      {:error, ereason} ->
+        Logger.info("AppServerLoad Report Failed: Hackney Error: #{inspect ereason}")
+        :error
+
+      r ->
+        Logger.info("AppServerLoad Report Failed: Unknown Hackney Error: #{inspect r}")
+        :error
+    end
+  end
+
+  defp headers do
+    [
+      {"Agent-Hostname", ScoutApm.Utils.hostname()},
+      {"Agent-Version", ScoutApm.Utils.agent_version()},
+
+      # This is not technically correct, it should be application/json
+      # or a custom content-type, but due to how ingest works, this is the
+      # correct thing for now.
+      {"Content-Type", "application/octet-stream"},
+    ]
+  end
+end

--- a/lib/scout_apm/payload/app_server_load.ex
+++ b/lib/scout_apm/payload/app_server_load.ex
@@ -1,0 +1,21 @@
+defmodule ScoutApm.Payload.AppServerLoad do
+  def new() do
+    %{
+      server_time:        NaiveDateTime.utc_now() |> DateTime.from_naive!("Etc/UTC") |> DateTime.to_iso8601(),
+      libraries:          libraries(),
+      # framework:          ScoutApm::Environment.instance.framework_integration.human_name,
+      # framework_version:  ScoutApm::Environment.instance.framework_integration.version,
+      # environment:        ScoutApm::Environment.instance.framework_integration.env,
+      # hostname:           ScoutApm::Environment.instance.hostname,
+      # application_name:   ScoutApm::Environment.instance.application_name,
+      # paas:               ScoutApm::Environment.instance.platform_integration.name,
+      # git_sha:            ScoutApm::Environment.instance.git_revision.sha
+    }
+  end
+
+  defp libraries do
+    Enum.map(
+      Application.loaded_applications(),
+      fn {name, _desc, version} -> [name, to_string version] end)
+  end
+end

--- a/lib/scout_apm/payload/app_server_load.ex
+++ b/lib/scout_apm/payload/app_server_load.ex
@@ -1,13 +1,22 @@
 defmodule ScoutApm.Payload.AppServerLoad do
+  @moduledoc """
+  A separate payload from the rest, this is data sent up at application
+  boot time. This allows the UI to know immeidately when a new application
+  starts up, and helps us debug interactions with various 3rd party libraries
+  """
+
+  @doc """
+  Create a new Map containing the payload.
+  """
   def new() do
     %{
-      server_time:        NaiveDateTime.utc_now() |> DateTime.from_naive!("Etc/UTC") |> DateTime.to_iso8601(),
-      libraries:          libraries(),
+      server_time:          NaiveDateTime.utc_now() |> DateTime.from_naive!("Etc/UTC") |> DateTime.to_iso8601(),
+      libraries:            libraries(),
+      application_name:     ScoutApm.Config.find(:name),
+      hostname:             ScoutApm.Utils.hostname(),
       # framework:          ScoutApm::Environment.instance.framework_integration.human_name,
       # framework_version:  ScoutApm::Environment.instance.framework_integration.version,
       # environment:        ScoutApm::Environment.instance.framework_integration.env,
-      # hostname:           ScoutApm::Environment.instance.hostname,
-      # application_name:   ScoutApm::Environment.instance.application_name,
       # paas:               ScoutApm::Environment.instance.platform_integration.name,
       # git_sha:            ScoutApm::Environment.instance.git_revision.sha
     }
@@ -16,6 +25,6 @@ defmodule ScoutApm.Payload.AppServerLoad do
   defp libraries do
     Enum.map(
       Application.loaded_applications(),
-      fn {name, _desc, version} -> [name, to_string version] end)
+      fn {name, _desc, version} -> [to_string(name), to_string(version)] end)
   end
 end


### PR DESCRIPTION
Sends basic info about the agent and its environment at boot time of an application.

This is mostly useful for updating the ui faster during onboarding and debugging of agent issues.