### PR TITLE
Adding a `direct_host` option to fix loading DevTrace assets

### DIFF
--- a/lib/scout_apm/config/defaults.ex
+++ b/lib/scout_apm/config/defaults.ex
@@ -2,6 +2,7 @@ defmodule ScoutApm.Config.Defaults do
   def load do
     %{
       host: "https://checkin.scoutapp.com",
+      direct_host: "https://apm.scoutapp.com",
       dev_trace: false,
       monitor: true
     }

--- a/lib/scout_apm/devtrace/plug.ex
+++ b/lib/scout_apm/devtrace/plug.ex
@@ -48,7 +48,7 @@ defmodule ScoutApm.DevTrace.Plug do
   end
 
   defp apm_host do
-    ScoutApm.Config.find(:host)
+    ScoutApm.Config.find(:direct_host)
   end
 
   defp cachebust_time do


### PR DESCRIPTION
DevTrace assets were trying to load thru the ingestion pipeline, which is incorrect. This adds a `direct_host` option and loads the assets from there.

It's likely only to be used in development.

This fixes the missing asset mentioned in #17.