### PR TITLE
Less info-level logging on the per-minute reporting cycles

### DIFF
--- a/lib/scout_apm/reporter.ex
+++ b/lib/scout_apm/reporter.ex
@@ -49,7 +49,7 @@ defmodule ScoutApm.Reporter do
 
     header_list = headers()
 
-    Logger.info("Reporting ScoutAPM Payload to #{url}")
+    Logger.debug("Reporting ScoutAPM Payload to #{url}")
     Logger.debug("Payload Size. JSON: #{inspect :erlang.iolist_size(encoded_payload)}, Gzipped: #{inspect :erlang.iolist_size(gzipped_payload)}")
     # Logger.debug("JSON Payload: #{inspect encoded_payload}")
     # Logger.debug("Headers: #{inspect header_list}")
@@ -60,7 +60,7 @@ defmodule ScoutApm.Reporter do
         Logger.info("Reporting ScoutAPM Payload Failed with #{status_code}. Response Headers: #{inspect resp_headers}")
 
       {:ok, status_code, _resp_headers, _client_ref} when status_code in @success_http_codes ->
-        Logger.info("Reporting ScoutAPM Payload Succeeded. Status: #{inspect status_code}")
+        Logger.debug("Reporting ScoutAPM Payload Succeeded. Status: #{inspect status_code}")
 
       {:ok, status_code, _resp_headers, _client_ref} ->
         Logger.info("Reporting ScoutAPM Payload Unexpected Status: #{inspect status_code}")

--- a/lib/scout_apm/store_reporting_period.ex
+++ b/lib/scout_apm/store_reporting_period.ex
@@ -84,7 +84,7 @@ defmodule ScoutApm.StoreReportingPeriod do
         ScoredItemSet.to_list(state.traces, :without_scores),
         state.histograms
       )
-      Logger.info("Reporting: Payload created with data from #{ScoutApm.Payload.total_call_count(payload)} requests.")
+      Logger.debug("Reporting: Payload created with data from #{ScoutApm.Payload.total_call_count(payload)} requests.")
       Logger.debug("Payload #{inspect payload}")
 
       encoded = ScoutApm.Payload.encode(payload)


### PR DESCRIPTION
Previously we'd log the following on the per-minute reporting cycles:

```
15:20:07.638 application=scout_apm [info] Reporting: Payload created with data from 7 requests.
15:20:07.644 application=scout_apm [info] Reporting ScoutAPM Payload to http://localhost:3000/apps/checkin.scout?key=[KEY]&name=[APP NAME]
15:20:07.947 application=scout_apm [info] Reporting ScoutAPM Payload Succeeded. Status: 200
```

Now, nothing is logged when the payload is created and reported without error.

Closes #20.