### PR TITLE
Background Job Metrics & Traces

### DIFF
--- a/lib/scout_apm/collector.ex
+++ b/lib/scout_apm/collector.ex
@@ -5,7 +5,7 @@ defmodule ScoutApm.Collector do
 
   alias ScoutApm.Internal.Duration
   alias ScoutApm.Internal.Metric
-  alias ScoutApm.Internal.Trace
+  alias ScoutApm.Internal.WebTrace
   alias ScoutApm.Internal.JobTrace
   alias ScoutApm.Internal.Layer
   alias ScoutApm.Internal.JobRecord
@@ -41,9 +41,12 @@ defmodule ScoutApm.Collector do
   ########################
   #  Collect Histograms  #
   ########################
+
   def store_histograms(tracked_request) do
     root_layer = tracked_request.root_layer
     duration = Layer.total_time(root_layer)
+
+    # TODO: This knowledge of how to build a key is here, and in score_key of WebTrace & JobTrace modules
     key = "#{root_layer.type}/#{root_layer.name}"
 
     # Store into this minute's histogram
@@ -78,7 +81,7 @@ defmodule ScoutApm.Collector do
 
   def store_web_trace(tracked_request) do
     tracked_request
-    |> Trace.from_tracked_request()
+    |> WebTrace.from_tracked_request()
     |> ScoutApm.Store.record_web_trace()
   end
 

--- a/lib/scout_apm/collector.ex
+++ b/lib/scout_apm/collector.ex
@@ -17,7 +17,7 @@ defmodule ScoutApm.Collector do
   def record(tracked_request) do
     scope = request_scope(tracked_request)
     store_histograms(tracked_request)
-    store_metrics(tracked_request.root_layer, scope)
+    store_web_metrics(tracked_request.root_layer, scope)
     store_web_trace(tracked_request)
   end
 
@@ -46,13 +46,13 @@ defmodule ScoutApm.Collector do
   #  Collect Metric  #
   ####################
 
-  def store_metrics(layer, scope) do
+  def store_web_metrics(layer, scope) do
     # Track self
     ScoutApm.Store.record_web_metric(Metric.from_layer(layer, scope))
 
     # Recurse into any children.
     # This isn't tail recursive, probably no biggie
-    Enum.each(layer.children, fn child -> store_metrics(child, scope) end)
+    Enum.each(layer.children, fn child -> store_web_metrics(child, scope) end)
   end
 
   ###################

--- a/lib/scout_apm/collector.ex
+++ b/lib/scout_apm/collector.ex
@@ -27,7 +27,7 @@ defmodule ScoutApm.Collector do
         :ok
 
       :job ->
-        store_job_metrics(tracked_request.root_layer, scope)
+        store_job_metrics(tracked_request.root_layer, ScopeStack.layer_to_scope(tracked_request.root_layer))
         store_job_trace(tracked_request)
         :ok
 

--- a/lib/scout_apm/collector.ex
+++ b/lib/scout_apm/collector.ex
@@ -60,7 +60,8 @@ defmodule ScoutApm.Collector do
   ###################
 
   def store_web_trace(tracked_request) do
-    Trace.from_tracked_request(tracked_request)
+    tracked_request
+    |> Trace.from_tracked_request()
     |> ScoutApm.Store.record_web_trace()
   end
 

--- a/lib/scout_apm/collector.ex
+++ b/lib/scout_apm/collector.ex
@@ -1,4 +1,8 @@
 defmodule ScoutApm.Collector do
+  @moduledoc """
+  Takes a TrackedRequest, and routes it onward to the correct Store
+  """
+
   alias ScoutApm.Internal.Duration
   alias ScoutApm.Internal.Metric
   alias ScoutApm.Internal.Trace
@@ -14,7 +18,7 @@ defmodule ScoutApm.Collector do
     scope = request_scope(tracked_request)
     store_histograms(tracked_request)
     store_metrics(tracked_request.root_layer, scope)
-    store_trace(tracked_request)
+    store_web_trace(tracked_request)
   end
 
   # For now, scope is simply the root layer
@@ -44,7 +48,7 @@ defmodule ScoutApm.Collector do
 
   def store_metrics(layer, scope) do
     # Track self
-    ScoutApm.Store.record_metric(Metric.from_layer(layer, scope))
+    ScoutApm.Store.record_web_metric(Metric.from_layer(layer, scope))
 
     # Recurse into any children.
     # This isn't tail recursive, probably no biggie
@@ -55,9 +59,9 @@ defmodule ScoutApm.Collector do
   #  Collect Trace  #
   ###################
 
-  def store_trace(tracked_request) do
+  def store_web_trace(tracked_request) do
     Trace.from_tracked_request(tracked_request)
-    |> ScoutApm.Store.record_trace()
+    |> ScoutApm.Store.record_web_trace()
   end
 
 end

--- a/lib/scout_apm/devtrace/store.ex
+++ b/lib/scout_apm/devtrace/store.ex
@@ -1,5 +1,5 @@
 defmodule ScoutApm.DevTrace.Store do
-  alias ScoutApm.Internal.Trace
+  alias ScoutApm.Internal.WebTrace
   alias ScoutApm.Payload.SlowTransaction
   require Logger
 
@@ -19,7 +19,7 @@ defmodule ScoutApm.DevTrace.Store do
 
   def transaction do
     if get_tracked_request() do
-      get_tracked_request() |> Trace.from_tracked_request |> SlowTransaction.new
+      get_tracked_request() |> WebTrace.from_tracked_request |> SlowTransaction.new
     else
       %{}
     end

--- a/lib/scout_apm/internal/context.ex
+++ b/lib/scout_apm/internal/context.ex
@@ -6,6 +6,15 @@ defmodule ScoutApm.Internal.Context do
 
   defstruct [:type, :key, :value]
 
+  @valid_types [:user, :extra]
+  @type context_types :: :user | :extra
+
+  @type t :: %__MODULE__{
+    type: context_types,
+    key: String.t,
+    value: number | boolean | String.t,
+  }
+
   def new(type, key, value) do
     case {valid_type?(type), valid_key?(key), valid_value?(value)} do
       {false, _, _} ->
@@ -22,8 +31,7 @@ defmodule ScoutApm.Internal.Context do
     end
   end
 
-  @types [:user, :extra]
-  defp valid_type?(t) when t in @types, do: true
+  defp valid_type?(t) when t in @valid_types, do: true
   defp valid_type?(_), do: false
 
   defp valid_key?(key) when is_binary(key), do: String.printable?(key)

--- a/lib/scout_apm/internal/job_record.ex
+++ b/lib/scout_apm/internal/job_record.ex
@@ -1,0 +1,116 @@
+defmodule ScoutApm.Internal.JobRecord do
+  @moduledoc """
+  Stores a single or multiple runs of a background job.
+  Both metadata ("queue" and "name"), and metrics ("total time", "metrics")
+  """
+
+  alias ScoutApm.MetricSet
+  alias ScoutApm.Internal.Metric
+  alias ScoutApm.Internal.Layer
+  alias ScoutApm.Internal.Duration
+
+  @type t :: %__MODULE__{
+    queue: String.t,
+    name: String.t,
+    count: non_neg_integer,
+    errors: non_neg_integer,
+    total_time: ApproximateHistogram.t,
+    exclusive_time: ApproximateHistogram.t,
+    metrics: MetricSet.t,
+  }
+
+  defstruct [
+    :queue,
+    :name,
+
+    :count,
+    :errors,
+
+    :total_time,
+    :exclusive_time,
+
+    :metrics,
+  ]
+
+  ##################
+  #  Construction  #
+  ##################
+
+  @spec from_layer(Layer.t, any) :: t
+  @doc """
+  Given a Job layer (probably the root-layer of a TrackedRequest), turn it
+  into a JobRecord, with fully populated metrics and timing info
+  """
+  def from_layer(%Layer{type: type} = layer, scope) when type == "Job" do
+    queue_name = "default"
+
+    %__MODULE__{
+      queue: queue_name,
+      name: layer.name,
+      count: 1,
+      errors: 0,
+      total_time: ApproximateHistogram.add(
+        ApproximateHistogram.new(),
+        layer |> Layer.total_time() |> Duration.as(:seconds)),
+      exclusive_time: ApproximateHistogram.add(
+        ApproximateHistogram.new(),
+        layer |> Layer.total_exclusive_time() |> Duration.as(:seconds)),
+      metrics: create_metrics(layer, scope, MetricSet.new()),
+    }
+  end
+
+  # Depth-first walk of the layer tree, diving all the way to the leaf
+  # nodes, then collecting the child and its peers as its walked back up
+  # the call stack to the parent
+  defp create_metrics(%Layer{} = layer, scope, %MetricSet{} = metric_set) do
+    # Collect up all children layers' metrics first
+
+    layer.children
+    |> Enum.reduce(metric_set, fn child, set -> create_metrics(child, scope, set) end)
+
+    # Then collect this layer's metrics
+    |> MetricSet.absorb(Metric.from_layer(layer, %{}))
+  end
+
+  @spec key(t) :: String.t
+  def key(%__MODULE__{} = job_record) do
+    job_record.queue <> "/" <> job_record.name
+  end
+
+
+  #######################
+  #  Updater Functions  #
+  #######################
+
+  @spec merge(t, t) :: t
+  def merge(%__MODULE__{queue: queue1, name: name1} = m1,
+            %__MODULE__{queue: queue2, name: name2} = m2)
+            when queue1 == queue2
+             and name1 == name2
+            do
+    %__MODULE__{
+      queue: m1.queue,
+      name: m1.name,
+
+      count: m1.count + m2.count,
+      errors: m1.errors + m2.errors,
+
+      total_time: merge_histos(m1.total_time, m2.total_time),
+      exclusive_time: merge_histos(m1.exclusive_time, m2.exclusive_time),
+      metrics: MetricSet.merge(m1.metrics, m2.metrics),
+    }
+  end
+
+  defp merge_histos(h1, h2) do
+    h1
+    |> ApproximateHistogram.to_list
+    |> Enum.reduce(h2, fn {val, count}, memo ->
+      Enum.reduce(1..count, memo, fn _, m -> ApproximateHistogram.add(m, val) end)
+    end)
+  end
+
+  #############
+  #  Queries  #
+  #############
+
+end

--- a/lib/scout_apm/internal/job_trace.ex
+++ b/lib/scout_apm/internal/job_trace.ex
@@ -111,8 +111,9 @@ defmodule ScoutApm.Internal.JobTrace do
     {{:score, score(trace), score_key(trace)}, trace}
   end
 
+  # TODO: Re-add the queue name to the trace key
   defp score_key(%__MODULE__{} = trace) do
-    "Job/" <> trace.queue_name <> "/" <> trace.job_name
+    "Job/" <> trace.job_name
   end
 
   def score(%__MODULE__{} = trace) do

--- a/lib/scout_apm/internal/job_trace.ex
+++ b/lib/scout_apm/internal/job_trace.ex
@@ -6,6 +6,7 @@ defmodule ScoutApm.Internal.JobTrace do
   alias ScoutApm.Internal.Metric
   alias ScoutApm.Internal.Layer
   alias ScoutApm.MetricSet
+  alias ScoutApm.ScopeStack
 
   defstruct [
     :queue_name,

--- a/lib/scout_apm/internal/web_trace.ex
+++ b/lib/scout_apm/internal/web_trace.ex
@@ -1,4 +1,4 @@
-defmodule ScoutApm.Internal.Trace do
+defmodule ScoutApm.Internal.WebTrace do
   @moduledoc """
   A record of a single trace.
   """

--- a/lib/scout_apm/payload.ex
+++ b/lib/scout_apm/payload.ex
@@ -10,17 +10,17 @@ defmodule ScoutApm.Payload do
             histograms: []
 
 
-  def new(timestamp, metric_set, traces, histograms) do
+  def new(timestamp, web_metric_set, web_traces, histograms) do
     %ScoutApm.Payload{
       metadata: ScoutApm.Payload.Metadata.new(timestamp),
-      metrics: metrics(metric_set),
-      slow_transactions: make_traces(traces),
+      metrics: metrics(web_metric_set),
+      slow_transactions: make_traces(web_traces),
       histograms: make_histograms(histograms),
     }
   end
 
-  def metrics(%MetricSet{} = metric_set) do
-    metric_set
+  def metrics(%MetricSet{} = web_metric_set) do
+    web_metric_set
     |> ScoutApm.MetricSet.to_list
     |> Enum.map(fn metric -> make_metric(metric) end)
   end
@@ -29,13 +29,13 @@ defmodule ScoutApm.Payload do
     ScoutApm.Payload.Metric.new(metric)
   end
 
-  def make_traces(traces) do
-    traces
-      |> Enum.map(fn trace -> make_trace(trace) end)
+  def make_traces(web_traces) do
+    web_traces
+    |> Enum.map(fn trace -> make_trace(trace) end)
   end
 
-  def make_trace(trace) do
-    ScoutApm.Payload.SlowTransaction.new(trace)
+  def make_trace(web_trace) do
+    ScoutApm.Payload.SlowTransaction.new(web_trace)
   end
 
   def make_histograms(%{} = histograms) do

--- a/lib/scout_apm/payload.ex
+++ b/lib/scout_apm/payload.ex
@@ -10,12 +10,14 @@ defmodule ScoutApm.Payload do
             histograms: []
 
 
-  def new(timestamp, web_metric_set, web_traces, histograms) do
+  def new(timestamp, web_metric_set, web_traces, histograms, jobs, job_traces) do
     %ScoutApm.Payload{
       metadata: ScoutApm.Payload.Metadata.new(timestamp),
       metrics: metrics(web_metric_set),
       slow_transactions: make_traces(web_traces),
       histograms: make_histograms(histograms),
+      jobs: ScoutApm.Payload.Jobs.new(jobs),
+      slow_jobs: ScoutApm.Payload.SlowJobs.new(job_traces),
     }
   end
 

--- a/lib/scout_apm/payload/jobs.ex
+++ b/lib/scout_apm/payload/jobs.ex
@@ -2,7 +2,30 @@ defmodule ScoutApm.Payload.Jobs do
   @moduledoc """
   """
 
-  def new(_jobs) do
-    %{}
+  alias ScoutApm.MetricSet
+  alias ScoutApm.Internal.JobRecord
+  alias ScoutApm.Internal.Duration
+
+  @spec new(list(JobRecord.t)) :: list(map)
+  def new(jobs) do
+    jobs
+    |> Enum.map(&make_job/1)
   end
+
+  defp make_job(job) do
+    %{
+      queue: job.queue,
+      name: job.name,
+      count: job.count,
+      errors: job.errors,
+
+      total_time: job.total_time |> ApproximateHistogram.to_list() |> to_jsonable_histo,
+      exclusive_time: job.exclusive_time |> ApproximateHistogram.to_list() |> to_jsonable_histo,
+
+      metrics: ScoutApm.Payload.NewMetrics.new(job.metrics),
+    }
+  end
+
+  # A little mapping to turn histo's 2 tuples into 2 elem lists
+  defp to_jsonable_histo(histo), do: Enum.map(histo, &Tuple.to_list/1)
 end

--- a/lib/scout_apm/payload/jobs.ex
+++ b/lib/scout_apm/payload/jobs.ex
@@ -1,0 +1,8 @@
+defmodule ScoutApm.Payload.Jobs do
+  @moduledoc """
+  """
+
+  def new(_jobs) do
+    %{}
+  end
+end

--- a/lib/scout_apm/payload/new_metrics.ex
+++ b/lib/scout_apm/payload/new_metrics.ex
@@ -1,0 +1,46 @@
+defmodule ScoutApm.Payload.NewMetrics do
+  @moduledoc """
+  Awkward name - we have two different metric formats in the Ruby agent,
+  Jobs use this one. It's more flexible, but annoying that we have 2 formats
+  """
+
+  alias ScoutApm.Internal.Duration
+  alias ScoutApm.MetricSet
+
+  @spec new(MetricSet.t) :: list(map)
+  def new(%MetricSet{} = metric_set) do
+    metric_set
+    |> MetricSet.to_list()
+    |> Enum.map(
+         fn metric ->
+           # TODO: Handle Job queues correctly
+           # name = if metric.type == "Job" do
+             # "default/#{metric.name}"
+           # else
+             # metric.name
+           # end
+           name = metric.name
+
+           %{
+             bucket: metric.type,
+             name: name,
+             count: metric.call_count,
+             total_call_time: Duration.as(metric.total_time, :seconds),
+             total_exclusive_time: Duration.as(metric.exclusive_time, :seconds),
+             min_call_time: Duration.as(metric.min_time, :seconds),
+             max_call_time: Duration.as(metric.max_time, :seconds),
+
+             total_histogram: [Duration.as(metric.total_time, :seconds)/ metric.call_count, metric.call_count],
+             exclusive_histogram: [Duration.as(metric.exclusive_time, :seconds) / metric.call_count, metric.call_count],
+
+             detail: %{
+               desc: metric.desc,
+               # metric.extra stuff may need to go here? (backtraces?)
+             },
+
+             # Always empty list. Will be where child metrics go later.
+             metrics: [],
+           }
+         end)
+  end
+end

--- a/lib/scout_apm/payload/slow_jobs.ex
+++ b/lib/scout_apm/payload/slow_jobs.ex
@@ -1,0 +1,35 @@
+defmodule ScoutApm.Payload.SlowJobs do
+
+  alias ScoutApm.Internal.Duration
+
+  def new(job_traces) do
+    Enum.map(job_traces, &make_slow_job_payload/1)
+  end
+
+  def make_slow_job_payload(job_trace) do
+    %{
+      queue: job_trace.queue_name,
+      name: job_trace.job_name,
+      time: job_trace.time,
+
+      total_time: Duration.as(job_trace.total_time, :seconds),
+      exclusive_time: Duration.as(job_trace.exclusive_time, :seconds),
+
+      hostname: job_trace.hostname,
+      metrics: ScoutApm.Payload.NewMetrics.new(job_trace.metrics),
+      context: ScoutApm.Payload.Context.new(job_trace.contexts),
+
+      score: job_trace.score,
+
+      # Unimplemented parts of this payload. Kept here to remind us of
+      # the symmetry w/ the ruby agent
+      #
+      # allocation_metrics: MetricsToJsonSerializer.new(job.allocation_metrics).as_json, # New style of metrics
+      # truncated_metrics: job.truncated_metrics,
+      # git_sha: job.git_sha,
+      # allocations: job.allocations,
+      # mem_delta: job.mem_delta,
+      # seconds_since_startup: job.seconds_since_startup,
+    }
+  end
+end

--- a/lib/scout_apm/payload/slow_transaction.ex
+++ b/lib/scout_apm/payload/slow_transaction.ex
@@ -3,7 +3,7 @@ defmodule ScoutApm.Payload.SlowTransaction do
   The payload structure for a single SlowTransaction / Trace.
   """
 
-  alias ScoutApm.Internal.Trace
+  alias ScoutApm.Internal.WebTrace
   alias ScoutApm.Internal.Duration
 
   defstruct [
@@ -23,7 +23,7 @@ defmodule ScoutApm.Payload.SlowTransaction do
     :truncated_metrics,
   ]
 
-  def new(%Trace{} = trace) do
+  def new(%WebTrace{} = trace) do
     %__MODULE__{
       key: %{
         bucket: trace.type,

--- a/lib/scout_apm/store.ex
+++ b/lib/scout_apm/store.ex
@@ -12,7 +12,7 @@ defmodule ScoutApm.Store do
   require Logger
 
   alias ScoutApm.Internal.Metric
-  alias ScoutApm.Internal.Trace
+  alias ScoutApm.Internal.WebTrace
   alias ScoutApm.Internal.JobRecord
   alias ScoutApm.Internal.JobTrace
   alias ScoutApm.StoreReportingPeriod
@@ -35,7 +35,7 @@ defmodule ScoutApm.Store do
     end
   end
 
-  def record_web_trace(%Trace{} = trace) do
+  def record_web_trace(%WebTrace{} = trace) do
     case Process.whereis(__MODULE__) do
       nil -> Logger.info("Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
       pid ->
@@ -94,7 +94,7 @@ defmodule ScoutApm.Store do
 
   # TODO: Lazy-generate trace (ie, this should take a thunk that evaluates into a trace)
   # TODO: Score the thunk, so we can determine if the set wants to even bother resolving the trace
-  def handle_cast({:record_web_trace, %Trace{} = trace}, state) do
+  def handle_cast({:record_web_trace, %WebTrace{} = trace}, state) do
     {rp, new_state} = find_or_create_reporting_period(state)
     StoreReportingPeriod.record_web_trace(rp, trace)
     {:noreply, new_state}

--- a/lib/scout_apm/store_reporting_period.ex
+++ b/lib/scout_apm/store_reporting_period.ex
@@ -2,7 +2,7 @@ defmodule ScoutApm.StoreReportingPeriod do
   require Logger
 
   alias ScoutApm.Internal.Duration
-  alias ScoutApm.Internal.Trace
+  alias ScoutApm.Internal.WebTrace
   alias ScoutApm.Internal.JobRecord
   alias ScoutApm.Internal.JobTrace
   alias ScoutApm.MetricSet
@@ -28,7 +28,7 @@ defmodule ScoutApm.StoreReportingPeriod do
   def record_web_trace(pid, trace) do
     Agent.update(pid,
       fn state ->
-        %{state | web_traces: ScoredItemSet.absorb(state.web_traces, Trace.as_scored_item(trace))}
+        %{state | web_traces: ScoredItemSet.absorb(state.web_traces, WebTrace.as_scored_item(trace))}
       end
     )
   end

--- a/lib/scout_apm/tracing.ex
+++ b/lib/scout_apm/tracing.ex
@@ -40,6 +40,29 @@ defmodule ScoutApm.Tracing do
   end
 
   @doc """
+  Instruments a background job
+
+  ## Example Usage:
+
+      defmodule SendEmailJob do
+        import ScoutApm.Tracing
+
+        def perform() do
+          ScoutApm.Tracing.track_job("SendEmail", fn ->
+            # ... your job's work
+          end)
+        end
+      end
+  """
+  @spec track_job(String.t, any, function) :: any
+  def track_job(name, opts \\ [], function) when is_function(function) do
+    TrackedRequest.start_layer("Job", name, opts)
+    result = function.()
+    TrackedRequest.stop_layer()
+    result
+  end
+
+  @doc """
   Updates the description for the code executing within a call to `instrument/3`. The description is displayed
   within a Scout trace in the UI.
 

--- a/lib/scout_apm/tracked_request.ex
+++ b/lib/scout_apm/tracked_request.ex
@@ -65,9 +65,10 @@ defmodule ScoutApm.TrackedRequest do
     if Enum.count(layers(tr2)) == 0 do
       request = tr2 |> with_root_layer(updated_layer)
       request.collector_fn.(request)
+      request
+    else
+      tr2
     end
-
-    tr2
   end
 
   def track_layer(%__MODULE__{} = tr, type, name, duration, fields, callback) do

--- a/lib/scout_apm/utils.ex
+++ b/lib/scout_apm/utils.ex
@@ -12,6 +12,6 @@ defmodule ScoutApm.Utils do
 
   def hostname do
     {:ok, name} = :inet.gethostname()
-    name
+    to_string(name)
   end
 end

--- a/test/scout_apm/internal/job_record_test.exs
+++ b/test/scout_apm/internal/job_record_test.exs
@@ -1,0 +1,11 @@
+defmodule ScoutApm.Internal.JobRecordTest do
+  use ExUnit.Case, async: true
+
+  alias ScoutApm.Internal.JobRecord
+
+  describe "new/0" do
+    test "creating" do
+
+    end
+  end
+end

--- a/test/scout_apm/metric_set_test.exs
+++ b/test/scout_apm/metric_set_test.exs
@@ -68,6 +68,40 @@ defmodule ScoutApm.MetricSetTest do
     end
   end
 
+  describe "absorb_all" do
+    test "adds to metrics" do
+      set =
+        MetricSet.new
+        |> MetricSet.absorb_all([
+             make_metric("Ecto", "select"),
+             make_metric("Controller", "foo/bar"),
+             make_metric("EEx", "pages/index.html"),
+           ])
+
+      assert 3 == Enum.count(MetricSet.to_list(set))
+    end
+  end
+
+  describe "merge" do
+    test "merges the two sets of metrics" do
+      set1 = MetricSet.new |> MetricSet.absorb_all([
+        make_metric("Ecto", "select"),
+        make_metric("Controller", "foo/bar"),
+        make_metric("EEx", "pages/index.html"),
+      ])
+
+      set2 = MetricSet.new |> MetricSet.absorb_all([
+        make_metric("Ecto", "select"),
+        make_metric("Ecto", "delete"),
+        make_metric("EEx", "pages/layout.html"),
+      ])
+
+      merged = MetricSet.merge(set1, set2)
+
+      assert 5 == Enum.count(MetricSet.to_list(merged))
+    end
+  end
+
   defp make_metric(type, name, timing \\ 7.5) do
     Metric.from_sampler_value(type, name, timing)
   end

--- a/test/scout_apm/payload/jobs_test.exs
+++ b/test/scout_apm/payload/jobs_test.exs
@@ -1,0 +1,35 @@
+defmodule ScoutApm.Payload.JobRecordTest do
+  use ExUnit.Case, async: true
+
+  alias ScoutApm.Internal.JobRecord
+  alias ScoutApm.Payload.Jobs
+  alias ScoutApm.MetricSet
+
+  describe "new/1" do
+    test "with an empty list" do
+      assert [] == Jobs.new([])
+    end
+
+    test "from a single JobRecord" do
+      jr = %JobRecord{
+        queue: "q",
+        name: "name",
+        count: 1,
+        errors: 0,
+        total_time: ApproximateHistogram.new() |> ApproximateHistogram.add(1),
+        exclusive_time: ApproximateHistogram.new() |> ApproximateHistogram.add(1),
+        metrics: MetricSet.new(),
+      }
+
+      assert [%{
+                name: "name",
+                queue: "q",
+                count: 1,
+                errors: 0,
+                exclusive_time: [[1.0, 1]],
+                total_time: [[1.0, 1]],
+                metrics: [],
+              }] == Jobs.new([jr])
+    end
+  end
+end

--- a/test/scout_apm/tracked_request_test.exs
+++ b/test/scout_apm/tracked_request_test.exs
@@ -15,7 +15,7 @@ defmodule ScoutApm.TrackedRequestTest do
   test "starting a layer, then stopping calls the track function" do
     pid = self()
     TrackedRequest.new(fn r -> send(pid, {:complete, r}) end)
-    |> TrackedRequest.start_layer("foo", "bar")
+    |> TrackedRequest.start_layer("foo", "bar", [])
     |> TrackedRequest.stop_layer()
 
     receive do
@@ -31,8 +31,8 @@ defmodule ScoutApm.TrackedRequestTest do
   test "the root layer is whichever layer was started first" do
     pid = self()
     TrackedRequest.new(fn r -> send(pid, {:complete, r}) end)
-    |> TrackedRequest.start_layer("foo", "bar")
-      |> TrackedRequest.start_layer("nested", "x")
+    |> TrackedRequest.start_layer("foo", "bar", [])
+      |> TrackedRequest.start_layer("nested", "x", [])
       |> TrackedRequest.stop_layer()
     |> TrackedRequest.stop_layer()
 
@@ -50,12 +50,12 @@ defmodule ScoutApm.TrackedRequestTest do
   test "children get attached correctly" do
     pid = self()
     TrackedRequest.new(fn r -> send(pid, {:complete, r}) end)
-    |> TrackedRequest.start_layer("foo", "bar")
-      |> TrackedRequest.start_layer("nested", "x1")
-        |> TrackedRequest.start_layer("nested2", "y")
+    |> TrackedRequest.start_layer("foo", "bar", [])
+      |> TrackedRequest.start_layer("nested", "x1", [])
+        |> TrackedRequest.start_layer("nested2", "y", [])
         |> TrackedRequest.stop_layer()
       |> TrackedRequest.stop_layer()
-      |> TrackedRequest.start_layer("nested", "x2")
+      |> TrackedRequest.start_layer("nested", "x2", [])
       |> TrackedRequest.stop_layer()
     |> TrackedRequest.stop_layer()
 


### PR DESCRIPTION
This is an initial implementation of background job monitoring and tracing.

There's no automated instrumentation of any specific workers yet, to use this,
you'll need to wrap your job code in a tracing function:

```
def perform do
  ScoutApm.Tracing.track_job("MyJob", fn ->
    # Your work here.
  end)
end
```