### PR TITLE
Implement a passthrough ScoutApm.Logger module

### DIFF
--- a/lib/scout_apm/agent_note.ex
+++ b/lib/scout_apm/agent_note.ex
@@ -4,9 +4,7 @@ defmodule ScoutApm.AgentNote do
   occurances, or other things that'd normally be log messages.
   """
 
-  require Logger
-
   def note({:metric_type, :over_limit, max_types}) do
-    Logger.info("Skipping absorbing metric, over limit of #{max_types} unique metric types. See http://help.apm.scoutapp.com/#elixir-agent for more details")
+    ScoutApm.Logger.info("Skipping absorbing metric, over limit of #{max_types} unique metric types. See http://help.apm.scoutapp.com/#elixir-agent for more details")
   end
 end

--- a/lib/scout_apm/application_load_notification.ex
+++ b/lib/scout_apm/application_load_notification.ex
@@ -1,6 +1,5 @@
 defmodule ScoutApm.ApplicationLoadNotification do
   use GenServer
-  require Logger
 
   @name __MODULE__
 
@@ -40,7 +39,7 @@ defmodule ScoutApm.ApplicationLoadNotification do
         {:stop, :normal, state}
       :error ->
         if retries < 1 do
-          Logger.info("Failed to send AppServerLoad, aborting.")
+          ScoutApm.Logger.info("Failed to send AppServerLoad, aborting.")
           {:stop, :normal, state}
         else
           :timer.sleep(@wait_between_retries)
@@ -60,23 +59,23 @@ defmodule ScoutApm.ApplicationLoadNotification do
 
     case {monitor, key} do
       {nil, nil} ->
-        Logger.debug("Skipping AppServerLoad, both monitor and key settings are missing")
+        ScoutApm.Logger.debug("Skipping AppServerLoad, both monitor and key settings are missing")
         :ok
 
       {true, nil} ->
-        Logger.debug("Skipping AppServerLoad, key is nil")
+        ScoutApm.Logger.debug("Skipping AppServerLoad, key is nil")
         :ok
 
       {true, ""} ->
-        Logger.debug("Skipping AppServerLoad, key is empty")
+        ScoutApm.Logger.debug("Skipping AppServerLoad, key is empty")
         :ok
 
       {nil, _} ->
-        Logger.debug("Skipping AppServerLoad, monitor is nil")
+        ScoutApm.Logger.debug("Skipping AppServerLoad, monitor is nil")
         :ok
 
       {false, _} ->
-        Logger.debug("Skipping AppServerLoad, monitor is false")
+        ScoutApm.Logger.debug("Skipping AppServerLoad, monitor is false")
         :ok
 
       _ ->
@@ -97,23 +96,23 @@ defmodule ScoutApm.ApplicationLoadNotification do
 
     case :hackney.request(method, url, header_list , encoded_payload, options) do
       {:ok, status_code, _resp_headers, _client_ref} when status_code in @success_http_codes ->
-        Logger.info("AppServerLoad Report Succeeded. Status: #{inspect status_code}")
+        ScoutApm.Logger.info("AppServerLoad Report Succeeded. Status: #{inspect status_code}")
         :ok
 
       {:ok, status_code, resp_headers, _client_ref} when status_code in @error_http_codes ->
-        Logger.info("AppServerLoad Report Failed with #{status_code}. Response Headers: #{inspect resp_headers}")
+        ScoutApm.Logger.info("AppServerLoad Report Failed with #{status_code}. Response Headers: #{inspect resp_headers}")
         :error
 
       {:ok, status_code, _resp_headers, _client_ref} ->
-        Logger.info("AppServerLoad Report Unexpected Status: #{inspect status_code}")
+        ScoutApm.Logger.info("AppServerLoad Report Unexpected Status: #{inspect status_code}")
         :error
 
       {:error, ereason} ->
-        Logger.info("AppServerLoad Report Failed: Hackney Error: #{inspect ereason}")
+        ScoutApm.Logger.info("AppServerLoad Report Failed: Hackney Error: #{inspect ereason}")
         :error
 
       r ->
-        Logger.info("AppServerLoad Report Failed: Unknown Hackney Error: #{inspect r}")
+        ScoutApm.Logger.info("AppServerLoad Report Failed: Unknown Hackney Error: #{inspect r}")
         :error
     end
   end

--- a/lib/scout_apm/config.ex
+++ b/lib/scout_apm/config.ex
@@ -10,8 +10,6 @@ defmodule ScoutApm.Config do
 
   use GenServer
 
-  require Logger
-
   alias ScoutApm.Config.Coercions
 
   @name __MODULE__
@@ -46,7 +44,7 @@ defmodule ScoutApm.Config do
           {:ok, c} ->
             {:halt, c}
           :error ->
-            Logger.info("Coercion of configuration #{key} failed. Ignoring")
+            ScoutApm.Logger.info("Coercion of configuration #{key} failed. Ignoring")
             {:cont, nil}
         end
       else

--- a/lib/scout_apm/context.ex
+++ b/lib/scout_apm/context.ex
@@ -6,8 +6,6 @@ defmodule ScoutApm.Context do
   since the correct underlying TrackedRequest is looked up that way.
   """
 
-  require Logger
-
   @doc """
   Returns :ok on success
   Returns {:error, {:arg, reason}} on failure

--- a/lib/scout_apm/devtrace/plug.ex
+++ b/lib/scout_apm/devtrace/plug.ex
@@ -1,6 +1,5 @@
 defmodule ScoutApm.DevTrace.Plug do
   import Plug.Conn
-  require Logger
 
   # This monkey-patches XMLHttpRequest. It could possibly be part of the main scout_instant.js too. This is placed in the HTML HEAD so it loads as soon as possible.
   xml_http_script_path  = Application.app_dir(:scout_apm, "priv/static/devtrace/xml_http_script.html")

--- a/lib/scout_apm/devtrace/store.ex
+++ b/lib/scout_apm/devtrace/store.ex
@@ -1,7 +1,6 @@
 defmodule ScoutApm.DevTrace.Store do
   alias ScoutApm.Internal.WebTrace
   alias ScoutApm.Payload.SlowTransaction
-  require Logger
 
   @trace_key :tracked_request
 
@@ -14,7 +13,7 @@ defmodule ScoutApm.DevTrace.Store do
   end
 
   def payload do
-    Map.merge(transaction(),%{metadata: metadata()})
+    Map.merge(transaction(), %{metadata: metadata()})
   end
 
   def transaction do

--- a/lib/scout_apm/instruments/eex_engine.ex
+++ b/lib/scout_apm/instruments/eex_engine.ex
@@ -1,8 +1,6 @@
 defmodule ScoutApm.Instruments.EExEngine do
   @behaviour Phoenix.Template.Engine
 
-  require Logger
-
   # TODO: Make this name correctly for other template locations
   # Currently it assumes too much about being located under `web/templates`
   def compile(path, name) do

--- a/lib/scout_apm/internal/job_trace.ex
+++ b/lib/scout_apm/internal/job_trace.ex
@@ -1,6 +1,4 @@
 defmodule ScoutApm.Internal.JobTrace do
-  require Logger
-
   alias ScoutApm.Internal.Context
   alias ScoutApm.Internal.Duration
   alias ScoutApm.Internal.Metric
@@ -151,7 +149,7 @@ defmodule ScoutApm.Internal.JobTrace do
     else
       # If we failed to lookup the percentile, just give back a 0 score.
       err ->
-        Logger.debug("Failed to get percentile_score, error: #{err}")
+        ScoutApm.Logger.debug("Failed to get percentile_score, error: #{err}")
         0
     end
   end

--- a/lib/scout_apm/internal/web_trace.ex
+++ b/lib/scout_apm/internal/web_trace.ex
@@ -3,8 +3,6 @@ defmodule ScoutApm.Internal.WebTrace do
   A record of a single trace.
   """
 
-  require Logger
-
   alias ScoutApm.MetricSet
   alias ScoutApm.Internal.Duration
   alias ScoutApm.Internal.Metric
@@ -154,7 +152,7 @@ defmodule ScoutApm.Internal.WebTrace do
     else
       # If we failed to lookup the percentile, just give back a 0 score.
       err ->
-        Logger.debug("Failed to get percentile_score, error: #{err}")
+        ScoutApm.Logger.debug("Failed to get percentile_score, error: #{err}")
         0
     end
   end

--- a/lib/scout_apm/logger.ex
+++ b/lib/scout_apm/logger.ex
@@ -1,0 +1,97 @@
+defmodule ScoutApm.Logger do
+  @moduledoc """
+  Logger for all ScoutApm modules.
+
+  Defaults to pass-through to the built-in Logger, but checks first if
+  the agent is set to monitor: false, or set to a higher log level.
+
+  This is a GenServer, to easily state on what log level we're at and if
+  something should be sent along.
+
+  This doesn't currently attempt any fancy log-message elimination
+  macros that the core Logger does.
+  """
+  use GenServer
+
+  require Logger
+
+  @name __MODULE__
+
+  @default_level :info
+
+  @valid_levels [:debug, :info, :warn, :error]
+
+  # If you request to log a message at the left level, check if the
+  # logger's current level is one of the right before letting it through
+  #
+  # For instance, if you ScoutApm.Logger.warn("foo"), it should be
+  # printed if you're at warn, info, or debug levels
+  #
+  # Msg Lvl       Logger Lvl
+  #  |              |
+  #  |              |
+  #  v              v
+  @debug_levels [:debug]
+  @info_levels  [:debug, :info]
+  @warn_levels  [:debug, :info, :warn]
+  @error_levels [:debug, :info, :warn, :error]
+
+
+  ################
+  #  Client API  #
+  ################
+
+  def start_link(level \\ @default_level), do: GenServer.start_link(__MODULE__, level, name: @name)
+
+  def set_level(level), do: GenServer.cast(@name, {:set_level, level})
+  def set_enabled(value) when is_boolean(value), do: GenServer.cast(@name, {:set_enabled, value})
+  def enable!(), do: set_enabled(true)
+  def disable!(), do: set_enabled(false)
+
+  def reconfigure_from_config(), do: GenServer.cast(@name, :reconfigure_from_config)
+
+  def debug(msg, metadata \\ []), do: GenServer.cast(@name, {:debug, msg, metadata})
+  def info(msg, metadata \\ []), do: GenServer.cast(@name, {:info, msg, metadata})
+  def warn(msg, metadata \\ []), do: GenServer.cast(@name, {:warn, msg, metadata})
+  def error(msg, metadata \\ []), do: GenServer.cast(@name, {:error, msg, metadata})
+
+  def level(), do: GenServer.call(@name, :level)
+  def enabled?(), do: GenServer.call(@name, :enabled)
+
+  ################
+  #  Server API  #
+  ################
+  def init(level) do
+    state = %{level: level, enabled: true}
+    {:ok, state}
+  end
+
+  def handle_call(:level, _from, %{level: level} = state), do: {:reply, level, state}
+  def handle_call(:enabled, _from, %{enabled: enabled} = state), do: {:reply, enabled, state}
+
+  def handle_cast(:reconfigure_from_config, state) do
+    level = ScoutApm.Config.find(:log_level) || @default_level
+    enabled = ScoutApm.Config.find(:monitor)
+
+    {
+      :noreply,
+      %{state |
+        level: level,
+        enabled: enabled
+      }
+    }
+  end
+
+  def handle_cast({:set_level, level}, state), do: %{state | level: level} |> noreply
+  def handle_cast({:set_enabled, value}, state), do: %{state | enabled: value} |> noreply
+
+  def handle_cast({msg_level, _, _}, %{enabled: false} = state) when msg_level in @valid_levels, do: noreply(state)
+  def handle_cast({:debug, msg, metadata}, %{level: level} = state) when level in @debug_levels, do: Logger.debug(msg, metadata) |> noreply(state)
+  def handle_cast({:info, msg, metadata},  %{level: level} = state) when level in @info_levels,  do: Logger.info(msg, metadata)  |> noreply(state)
+  def handle_cast({:warn, msg, metadata},  %{level: level} = state) when level in @warn_levels,  do: Logger.warn(msg, metadata)  |> noreply(state)
+  def handle_cast({:error, msg, metadata}, %{level: level} = state) when level in @error_levels, do: Logger.error(msg, metadata) |> noreply(state)
+  def handle_cast({msg_level, _, _}, state) when msg_level in @valid_levels, do: noreply(state)
+
+  defp noreply(state), do: {:noreply, state}
+  defp noreply(_, state), do: noreply(state)
+end

--- a/lib/scout_apm/plugs/controller_timer.ex
+++ b/lib/scout_apm/plugs/controller_timer.ex
@@ -1,8 +1,6 @@
 defmodule ScoutApm.Plugs.ControllerTimer do
   alias ScoutApm.Internal.Layer
 
-  require Logger
-
   def init(default), do: default
 
   def call(conn, _default) do
@@ -58,7 +56,7 @@ defmodule ScoutApm.Plugs.ControllerTimer do
       ScoutApm.Context.add_user(:ip, remote_ip)
     rescue
       err ->
-        Logger.debug("Failed adding IP context: #{inspect err}")
+        ScoutApm.Logger.debug("Failed adding IP context: #{inspect err}")
     end
   end
 end

--- a/lib/scout_apm/reporter.ex
+++ b/lib/scout_apm/reporter.ex
@@ -1,6 +1,4 @@
 defmodule ScoutApm.Reporter do
-  require Logger
-
   @success_http_codes 200..299
   @error_http_codes 400..499
 
@@ -10,23 +8,23 @@ defmodule ScoutApm.Reporter do
 
     case {monitor, key} do
       {nil, nil} ->
-        Logger.debug("Skipping Reporting, both monitor and key settings are missing")
+        ScoutApm.Logger.debug("Skipping Reporting, both monitor and key settings are missing")
         :ok
 
       {true, nil} ->
-        Logger.debug("Skipping Reporting, key is nil")
+        ScoutApm.Logger.debug("Skipping Reporting, key is nil")
         :ok
 
       {true, ""} ->
-        Logger.debug("Skipping Reporting, key is empty")
+        ScoutApm.Logger.debug("Skipping Reporting, key is empty")
         :ok
 
       {nil, _} ->
-        Logger.debug("Skipping Reporting, monitor is nil")
+        ScoutApm.Logger.debug("Skipping Reporting, monitor is nil")
         :ok
 
       {false, _} ->
-        Logger.debug("Skipping Reporting, monitor is false")
+        ScoutApm.Logger.debug("Skipping Reporting, monitor is false")
         :ok
 
       _ ->
@@ -49,27 +47,27 @@ defmodule ScoutApm.Reporter do
 
     header_list = headers()
 
-    Logger.debug("Reporting ScoutAPM Payload to #{url}")
-    Logger.debug("Payload Size. JSON: #{inspect :erlang.iolist_size(encoded_payload)}, Gzipped: #{inspect :erlang.iolist_size(gzipped_payload)}")
-    # Logger.debug("JSON Payload: #{inspect encoded_payload}")
-    # Logger.debug("Headers: #{inspect header_list}")
+    ScoutApm.Logger.debug("Reporting ScoutAPM Payload to #{url}")
+    ScoutApm.Logger.debug("Payload Size. JSON: #{inspect :erlang.iolist_size(encoded_payload)}, Gzipped: #{inspect :erlang.iolist_size(gzipped_payload)}")
+    # ScoutApm.Logger.debug("JSON Payload: #{inspect encoded_payload}")
+    # ScoutApm.Logger.debug("Headers: #{inspect header_list}")
 
     case :hackney.request(method, url, header_list , gzipped_payload, options) do
 
       {:ok, status_code, resp_headers, _client_ref} when status_code in @error_http_codes ->
-        Logger.info("Reporting ScoutAPM Payload Failed with #{status_code}. Response Headers: #{inspect resp_headers}")
+        ScoutApm.Logger.info("Reporting ScoutAPM Payload Failed with #{status_code}. Response Headers: #{inspect resp_headers}")
 
       {:ok, status_code, _resp_headers, _client_ref} when status_code in @success_http_codes ->
-        Logger.debug("Reporting ScoutAPM Payload Succeeded. Status: #{inspect status_code}")
+        ScoutApm.Logger.debug("Reporting ScoutAPM Payload Succeeded. Status: #{inspect status_code}")
 
       {:ok, status_code, _resp_headers, _client_ref} ->
-        Logger.info("Reporting ScoutAPM Payload Unexpected Status: #{inspect status_code}")
+        ScoutApm.Logger.info("Reporting ScoutAPM Payload Unexpected Status: #{inspect status_code}")
 
       {:error, ereason} ->
-        Logger.info("Reporting ScoutAPM Payload Failed: Hackney Error: #{inspect ereason}")
+        ScoutApm.Logger.info("Reporting ScoutAPM Payload Failed: Hackney Error: #{inspect ereason}")
 
       r ->
-        Logger.info("Reporting ScoutAPM Payload Failed: Unknown Hackney Error: #{inspect r}")
+        ScoutApm.Logger.info("Reporting ScoutAPM Payload Failed: Unknown Hackney Error: #{inspect r}")
     end
 
     :ok

--- a/lib/scout_apm/store.ex
+++ b/lib/scout_apm/store.ex
@@ -9,7 +9,6 @@ defmodule ScoutApm.Store do
   """
 
   use GenServer
-  require Logger
 
   alias ScoutApm.Internal.Metric
   alias ScoutApm.Internal.WebTrace
@@ -29,7 +28,7 @@ defmodule ScoutApm.Store do
 
   def record_web_metric(%Metric{} = metric) do
     case Process.whereis(__MODULE__) do
-      nil -> Logger.info("Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
+      nil -> ScoutApm.Logger.info("Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
       pid ->
         GenServer.cast(pid, {:record_web_metric, metric})
     end
@@ -37,7 +36,7 @@ defmodule ScoutApm.Store do
 
   def record_web_trace(%WebTrace{} = trace) do
     case Process.whereis(__MODULE__) do
-      nil -> Logger.info("Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
+      nil -> ScoutApm.Logger.info("Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
       pid ->
         GenServer.cast(pid, {:record_web_trace, trace})
     end
@@ -45,7 +44,7 @@ defmodule ScoutApm.Store do
 
   def record_job_record(%JobRecord{} = job_record) do
     case Process.whereis(__MODULE__) do
-      nil -> Logger.info("Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
+      nil -> ScoutApm.Logger.info("Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
       pid ->
         GenServer.cast(pid, {:record_job_record, job_record})
     end
@@ -53,7 +52,7 @@ defmodule ScoutApm.Store do
 
   def record_job_trace(%JobTrace{} = job_trace) do
     case Process.whereis(__MODULE__) do
-      nil -> Logger.info("Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
+      nil -> ScoutApm.Logger.info("Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
       pid ->
         GenServer.cast(pid, {:record_job_trace, job_trace})
     end
@@ -62,7 +61,7 @@ defmodule ScoutApm.Store do
 
   def record_per_minute_histogram(key, duration) do
     case Process.whereis(__MODULE__) do
-      nil -> Logger.info("Couldn't find worker!?")
+      nil -> ScoutApm.Logger.info("Couldn't find worker!?")
       pid ->
         GenServer.cast(pid, {:record_per_minute_histogram, key, duration})
     end
@@ -143,7 +142,7 @@ defmodule ScoutApm.Store do
 
   # Runs samplers, which should run once per-minute just before reporting.
   defp capture_samplers(reporting_period) do
-    Logger.debug("Capturing samplers")
+    ScoutApm.Logger.debug("Capturing samplers")
     Enum.each([ScoutApm.Instruments.Samplers.Memory], fn sampler ->
       sampler.metrics |> Enum.each(fn metric ->
         StoreReportingPeriod.record_sampler_metric(reporting_period, metric)

--- a/lib/scout_apm/store_reporting_period.ex
+++ b/lib/scout_apm/store_reporting_period.ex
@@ -1,6 +1,4 @@
 defmodule ScoutApm.StoreReportingPeriod do
-  require Logger
-
   alias ScoutApm.Internal.Duration
   alias ScoutApm.Internal.WebTrace
   alias ScoutApm.Internal.JobRecord
@@ -125,17 +123,17 @@ defmodule ScoutApm.StoreReportingPeriod do
         ScoredItemSet.to_list(state.job_traces, :without_scores)
       )
 
-      Logger.debug("Reporting: Payload created with data from #{ScoutApm.Payload.total_call_count(payload)} requests.")
-      Logger.debug("Payload #{inspect payload}")
+      ScoutApm.Logger.debug("Reporting: Payload created with data from #{ScoutApm.Payload.total_call_count(payload)} requests.")
+      ScoutApm.Logger.debug("Payload #{inspect payload}")
 
       encoded = ScoutApm.Payload.encode(payload)
 
-      Logger.debug("Encoded Payload: #{inspect encoded}")
+      ScoutApm.Logger.debug("Encoded Payload: #{inspect encoded}")
 
       ScoutApm.Reporter.report(encoded)
     rescue
-      e in RuntimeError -> Logger.info("Reporting runtime error: #{inspect e}")
-      e -> Logger.info("Reporting other error: #{inspect e}")
+      e in RuntimeError -> ScoutApm.Logger.info("Reporting runtime error: #{inspect e}")
+      e -> ScoutApm.Logger.info("Reporting other error: #{inspect e}")
     end
   end
 

--- a/lib/scout_apm/tracing.ex
+++ b/lib/scout_apm/tracing.ex
@@ -131,7 +131,7 @@ defmodule ScoutApm.Tracing do
   # Deprecated!
   @spec instrument(String.t, String.t, any, function) :: any
   def instrument(type, name, opts \\ [], function) when is_function(function) do
-    IO.warn("#{__MODULE__}.instrument/4 is deprecated, use #{__MODULE__}.timing/4 instead")
+    ScoutApm.Logger.warn("#{__MODULE__}.instrument/4 is deprecated, use #{__MODULE__}.timing/4 instead")
     TrackedRequest.start_layer(type, name, opts)
     result = function.()
     TrackedRequest.stop_layer()

--- a/lib/scout_apm/tracked_request.ex
+++ b/lib/scout_apm/tracked_request.ex
@@ -20,7 +20,6 @@ defmodule ScoutApm.TrackedRequest do
   """
 
   alias ScoutApm.Internal.Layer
-  require Logger
 
   defstruct [:root_layer, :layers, :children, :contexts, :collector_fn]
 

--- a/lib/scout_apm/watcher.ex
+++ b/lib/scout_apm/watcher.ex
@@ -5,7 +5,6 @@ defmodule ScoutApm.Watcher do
   """
 
   use GenServer
-  require Logger
 
   @server __MODULE__
 
@@ -20,12 +19,16 @@ defmodule ScoutApm.Watcher do
 
   def init(mod) do
     Process.monitor(mod)
-    Logger.info("Setup ScoutApm.Watcher on #{inspect mod}")
+    ScoutApm.Logger.info("Setup ScoutApm.Watcher on #{inspect mod}")
     {:ok, :ok}
   end
 
+  # If the logger itself is the one that died on us, we probably will
+  # not log that. Also, I'm not sure of the order of events. Say that
+  # `Store` crashes, both the supervisor and this watcher get notified,
+  # but the supervisor will shut down and restart this process as well.
   def handle_info({:DOWN, _, _, {what, _node}, reason}, state) do
-    Logger.info("ScoutAPM Watcher: #{inspect what} Stopped: #{inspect reason}")
+    ScoutApm.Logger.info("ScoutAPM Watcher: #{inspect what} Stopped: #{inspect reason}")
     {:stop, :normal, state}
   end
 end


### PR DESCRIPTION
Allows further customization of the log level from the agent.

2 Major features:
- A log level distinct from the application's level (app is at info, but
  scout is at warn). This is mostly useful for the console logger, since
  the file logger can already be setup in a way similar to this.
- Disables logging entirely when ScoutAPM agent is not enabled.