### PR TITLE
Add support loading config from ENV

### DIFF
--- a/lib/scout_apm/config.ex
+++ b/lib/scout_apm/config.ex
@@ -11,6 +11,7 @@ defmodule ScoutApm.Config do
   use GenServer
 
   alias ScoutApm.Config.Coercions
+  alias ScoutApm.Config.Env
 
   @name __MODULE__
 
@@ -39,7 +40,7 @@ defmodule ScoutApm.Config do
   def handle_call({:find, key}, _from, state) do
     val = Enum.reduce_while(state, nil, fn {mod, data}, _acc ->
       if mod.contains?(data, key) do
-        raw = mod.lookup(data, key)
+        raw = Env.parse(mod.lookup(data, key))
         case coercion(key).(raw) do
           {:ok, c} ->
             {:halt, c}
@@ -66,4 +67,3 @@ defmodule ScoutApm.Config do
   defp coercion(:monitor), do: &Coercions.boolean/1
   defp coercion(_), do: fn x -> {:ok, x} end
 end
-

--- a/lib/scout_apm/config/env.ex
+++ b/lib/scout_apm/config/env.ex
@@ -1,0 +1,9 @@
+defmodule ScoutApm.Config.Env do
+  @moduledoc """
+  Takes "raw" values from various config sources, and if those values are
+  in {:system, "VAR_NAME"} format it loads VAR_NAME value from ENV
+  """
+
+  def parse({:system, value}), do: System.get_env(value)
+  def parse(value), do: value
+end

--- a/test/scout_apm/config_test.exs
+++ b/test/scout_apm/config_test.exs
@@ -1,0 +1,21 @@
+defmodule ScoutApm.ConfigTest do
+  use ExUnit.Case, async: true
+
+  test "find/1 with plain value" do
+    Mix.Config.persist(scout_apm: [key: "abc123"])
+
+    key = ScoutApm.Config.find(:key)
+
+    assert key == "abc123"
+  end
+
+  test "find/1 with ENV variable" do
+    System.put_env("SCOUT_API_KEY", "xyz123")
+    Mix.Config.persist(scout_apm: [key: {:system, "SCOUT_API_KEY"}])
+
+    key = ScoutApm.Config.find(:key)
+    System.delete_env("SCOUT_API_KEY")
+
+    assert key == "xyz123"
+  end
+end


### PR DESCRIPTION
This allows to set `:key` via environmental variables on platforms such as Heroku without the need to rebuild the application.

Here is how to use it:

```elixir
# config/prod.exs
config :scout_apm,
  key: {:system, "SCOUT_API_KEY"}
```