### PR TITLE
Load configuration variables from ENV

### DIFF
--- a/lib/scout_apm/config.ex
+++ b/lib/scout_apm/config.ex
@@ -11,6 +11,7 @@ defmodule ScoutApm.Config do
   use GenServer
 
   alias ScoutApm.Config.Coercions
+  alias ScoutApm.Config.Env
 
   @name __MODULE__
 
@@ -39,7 +40,7 @@ defmodule ScoutApm.Config do
   def handle_call({:find, key}, _from, state) do
     val = Enum.reduce_while(state, nil, fn {mod, data}, _acc ->
       if mod.contains?(data, key) do
-        raw = mod.lookup(data, key)
+        raw = Env.parse(mod.lookup(data, key))
         case coercion(key).(raw) do
           {:ok, c} ->
             {:halt, c}
@@ -66,4 +67,3 @@ defmodule ScoutApm.Config do
   defp coercion(:monitor), do: &Coercions.boolean/1
   defp coercion(_), do: fn x -> {:ok, x} end
 end
-

--- a/lib/scout_apm/config.ex
+++ b/lib/scout_apm/config.ex
@@ -11,7 +11,6 @@ defmodule ScoutApm.Config do
   use GenServer
 
   alias ScoutApm.Config.Coercions
-  alias ScoutApm.Config.Env
 
   @name __MODULE__
 
@@ -29,6 +28,7 @@ defmodule ScoutApm.Config do
 
   def init(:ok) do
     initial_state = [
+      {ScoutApm.Config.Env, ScoutApm.Config.Env.load()},
       {ScoutApm.Config.Application, ScoutApm.Config.Application.load()},
       {ScoutApm.Config.Defaults, ScoutApm.Config.Defaults.load()},
       {ScoutApm.Config.Null, ScoutApm.Config.Null.load()},
@@ -40,7 +40,7 @@ defmodule ScoutApm.Config do
   def handle_call({:find, key}, _from, state) do
     val = Enum.reduce_while(state, nil, fn {mod, data}, _acc ->
       if mod.contains?(data, key) do
-        raw = Env.parse(mod.lookup(data, key))
+        raw = mod.lookup(data, key)
         case coercion(key).(raw) do
           {:ok, c} ->
             {:halt, c}

--- a/lib/scout_apm/config/application.ex
+++ b/lib/scout_apm/config/application.ex
@@ -1,3 +1,6 @@
+# Reads values set in mix configuration
+#
+# Supports the {:system, "MY_ENV_VAR"} syntax, in the same manner as many other libraries
 defmodule ScoutApm.Config.Application do
   def load do
     :no_data
@@ -8,6 +11,11 @@ defmodule ScoutApm.Config.Application do
   end
 
   def lookup(_data, key) do
-    Application.get_env(:scout_apm, key)
+    Application.get_env(:scout_apm, key) |> resolve
   end
+
+  # Takes "raw" values from various config sources, and if those values are
+  # in {:system, "VAR_NAME"} format it loads VAR_NAME value from ENV
+  defp resolve({:system, value}), do: System.get_env(value)
+  defp resolve(value), do: value
 end

--- a/lib/scout_apm/config/env.ex
+++ b/lib/scout_apm/config/env.ex
@@ -1,0 +1,9 @@
+defmodule ScoutApm.Config.Env do
+  @moduledoc """
+  Takes "raw" values from various config sources, and if those values are
+  in {:system, "VAR_NAME"} format it loads VAR_NAME value from ENV
+  """
+
+  def parse({:system, value}), do: System.get_env(value)
+  def parse(value), do: value
+end

--- a/lib/scout_apm/config/env.ex
+++ b/lib/scout_apm/config/env.ex
@@ -1,9 +1,24 @@
+# Looks up configurations in SCOUT_* namespace, in the same manner as the Ruby agent does.
+# For any given key ("monitor" for instance), it is uppercased, and prepended
+# with "SCOUT_" and then looked up in the environment.
+#
+# If you wish to define your own environment variables to use, instead of these
+# defaults, the Application config {:system, "MY_SCOUT_KEY_VAR"} approach allows
+# that
 defmodule ScoutApm.Config.Env do
-  @moduledoc """
-  Takes "raw" values from various config sources, and if those values are
-  in {:system, "VAR_NAME"} format it loads VAR_NAME value from ENV
-  """
+  def load do
+    :no_data
+  end
 
-  def parse({:system, value}), do: System.get_env(value)
-  def parse(value), do: value
+  def contains?(_data, key) do
+    System.get_env(env_name(key)) != nil
+  end
+
+  def lookup(_data, key) do
+    System.get_env(env_name(key))
+  end
+
+  @env_prefix "SCOUT_"
+  defp env_name(key) when is_atom(key), do: key |> to_string |> env_name
+  defp env_name(key) when is_binary(key), do: key |> String.upcase |> (fn k -> @env_prefix <> k end).()
 end

--- a/test/scout_apm/config_test.exs
+++ b/test/scout_apm/config_test.exs
@@ -9,13 +9,20 @@ defmodule ScoutApm.ConfigTest do
     assert key == "abc123"
   end
 
-  test "find/1 with ENV variable" do
-    System.put_env("SCOUT_API_KEY", "xyz123")
-    Mix.Config.persist(scout_apm: [key: {:system, "SCOUT_API_KEY"}])
+  test "find/1 with application defined ENV variable" do
+    System.put_env("APM_API_KEY", "xyz123")
+    Mix.Config.persist(scout_apm: [key: {:system, "APM_API_KEY"}])
 
     key = ScoutApm.Config.find(:key)
-    System.delete_env("SCOUT_API_KEY")
+    System.delete_env("APM_API_KEY")
 
     assert key == "xyz123"
+  end
+
+  test "find/1 with SCOUT_* ENV variables" do
+    System.put_env("SCOUT_KEY", "zxc")
+    key = ScoutApm.Config.find(:key)
+    assert key == "zxc"
+    System.delete_env("SCOUT_KEY")
   end
 end

--- a/test/scout_apm/config_test.exs
+++ b/test/scout_apm/config_test.exs
@@ -1,0 +1,21 @@
+defmodule ScoutApm.ConfigTest do
+  use ExUnit.Case, async: true
+
+  test "find/1 with plain value" do
+    Mix.Config.persist(scout_apm: [key: "abc123"])
+
+    key = ScoutApm.Config.find(:key)
+
+    assert key == "abc123"
+  end
+
+  test "find/1 with ENV variable" do
+    System.put_env("SCOUT_API_KEY", "xyz123")
+    Mix.Config.persist(scout_apm: [key: {:system, "SCOUT_API_KEY"}])
+
+    key = ScoutApm.Config.find(:key)
+    System.delete_env("SCOUT_API_KEY")
+
+    assert key == "xyz123"
+  end
+end


### PR DESCRIPTION
Split out the two approaches to ENV vars

In mix, you can set your own ENV var to look up. This matches with how
other libraries in the elixir ecosystem do environment variables.

```
config :scout_apm,
  key: {:system, "APM_API_KEY"}
```

To match our Ruby agent, and make configuration easier on Heroku and
similar platforms, we also have a set of automatically derived
configurations.  For any config option (`key`, `log_level`), upper case
it, and prepend "SCOUT_", and that value will be loaded.

SCOUT_LOG_LEVEL
SCOUT_KEY
SCOUT_MONITOR
