### PR TITLE
Add deferred_config for easier deployment

### DIFF
--- a/lib/scout_apm/application.ex
+++ b/lib/scout_apm/application.ex
@@ -5,6 +5,7 @@ defmodule ScoutApm.Application do
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
+    DeferredConfig.populate(:scout_apm)
 
     children = [
       worker(ScoutApm.Store, []),

--- a/mix.exs
+++ b/mix.exs
@@ -40,6 +40,8 @@ defmodule ScoutApm.Mixfile do
 
       {:approximate_histogram, "~>0.1.1"},
 
+      {:deferred_config, "~> 0.1.1"},
+
       #########################
       # Dev & Testing Deps
 

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,7 @@
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "certifi": {:hex, :certifi, "1.0.0", "1c787a85b1855ba354f0b8920392c19aa1d06b0ee1362f9141279620a5be2039", [:rebar3], []},
   "credo": {:hex, :credo, "0.7.3", "9827ab04002186af1aec014a811839a06f72aaae6cd5eed3919b248c8767dbf3", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
+  "deferred_config": {:hex, :deferred_config, "0.1.1", "ec912e9ee3c99b90a8d4bdec8fbd15309f4bd6729f30789e0ff6f595d06bbce5", [], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], []},
   "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},


### PR DESCRIPTION
This allows for runtime (deferred) configs

```
config :scout_apm,
  name: "MyApp",
  key: {:system, "SCOUT_KEY"}
```

Based on https://github.com/mrluc/deferred_config