### PR TITLE
Silence logging when no key present

### DIFF
--- a/lib/scout_apm/agent_note.ex
+++ b/lib/scout_apm/agent_note.ex
@@ -5,6 +5,6 @@ defmodule ScoutApm.AgentNote do
   """
 
   def note({:metric_type, :over_limit, max_types}) do
-    ScoutApm.Logger.info("Skipping absorbing metric, over limit of #{max_types} unique metric types. See http://help.apm.scoutapp.com/#elixir-agent for more details")
+    ScoutApm.Logger.log(:info, "Skipping absorbing metric, over limit of #{max_types} unique metric types. See http://help.apm.scoutapp.com/#elixir-agent for more details")
   end
 end

--- a/lib/scout_apm/application.ex
+++ b/lib/scout_apm/application.ex
@@ -10,14 +10,12 @@ defmodule ScoutApm.Application do
       worker(ScoutApm.Store, []),
       worker(ScoutApm.Config, []),
       worker(ScoutApm.PersistentHistogram, []),
-      worker(ScoutApm.Logger, []),
 
       worker(ScoutApm.ApplicationLoadNotification, [], [restart: :temporary]),
 
       worker(ScoutApm.Watcher, [ScoutApm.Store], id: :store_watcher),
       worker(ScoutApm.Watcher, [ScoutApm.Config], id: :config_watcher),
       worker(ScoutApm.Watcher, [ScoutApm.PersistentHistogram], id: :histogram_watcher),
-      worker(ScoutApm.Watcher, [ScoutApm.Logger], id: :logger_watcher),
     ]
 
     # Stupidly persistent. Really high max restarts for debugging
@@ -27,8 +25,7 @@ defmodule ScoutApm.Application do
 
     ScoutApm.Watcher.start_link(ScoutApm.Supervisor)
 
-    ScoutApm.Logger.reconfigure_from_config()
-    ScoutApm.Logger.info("ScoutAPM Started")
+    ScoutApm.Logger.log(:info, "ScoutAPM Started")
     {:ok, pid}
   end
 end

--- a/lib/scout_apm/application_load_notification.ex
+++ b/lib/scout_apm/application_load_notification.ex
@@ -39,7 +39,7 @@ defmodule ScoutApm.ApplicationLoadNotification do
         {:stop, :normal, state}
       :error ->
         if retries < 1 do
-          ScoutApm.Logger.info("Failed to send AppServerLoad, aborting.")
+          ScoutApm.Logger.log(:info, "Failed to send AppServerLoad, aborting.")
           {:stop, :normal, state}
         else
           :timer.sleep(@wait_between_retries)
@@ -59,23 +59,23 @@ defmodule ScoutApm.ApplicationLoadNotification do
 
     case {monitor, key} do
       {nil, nil} ->
-        ScoutApm.Logger.debug("Skipping AppServerLoad, both monitor and key settings are missing")
+        ScoutApm.Logger.log(:debug, "Skipping AppServerLoad, both monitor and key settings are missing")
         :ok
 
       {true, nil} ->
-        ScoutApm.Logger.debug("Skipping AppServerLoad, key is nil")
+        ScoutApm.Logger.log(:debug, "Skipping AppServerLoad, key is nil")
         :ok
 
       {true, ""} ->
-        ScoutApm.Logger.debug("Skipping AppServerLoad, key is empty")
+        ScoutApm.Logger.log(:debug, "Skipping AppServerLoad, key is empty")
         :ok
 
       {nil, _} ->
-        ScoutApm.Logger.debug("Skipping AppServerLoad, monitor is nil")
+        ScoutApm.Logger.log(:debug, "Skipping AppServerLoad, monitor is nil")
         :ok
 
       {false, _} ->
-        ScoutApm.Logger.debug("Skipping AppServerLoad, monitor is false")
+        ScoutApm.Logger.log(:debug, "Skipping AppServerLoad, monitor is false")
         :ok
 
       _ ->
@@ -96,23 +96,23 @@ defmodule ScoutApm.ApplicationLoadNotification do
 
     case :hackney.request(method, url, header_list , encoded_payload, options) do
       {:ok, status_code, _resp_headers, _client_ref} when status_code in @success_http_codes ->
-        ScoutApm.Logger.info("AppServerLoad Report Succeeded. Status: #{inspect status_code}")
+        ScoutApm.Logger.log(:info, "AppServerLoad Report Succeeded. Status: #{inspect status_code}")
         :ok
 
       {:ok, status_code, resp_headers, _client_ref} when status_code in @error_http_codes ->
-        ScoutApm.Logger.info("AppServerLoad Report Failed with #{status_code}. Response Headers: #{inspect resp_headers}")
+        ScoutApm.Logger.log(:info, "AppServerLoad Report Failed with #{status_code}. Response Headers: #{inspect resp_headers}")
         :error
 
       {:ok, status_code, _resp_headers, _client_ref} ->
-        ScoutApm.Logger.info("AppServerLoad Report Unexpected Status: #{inspect status_code}")
+        ScoutApm.Logger.log(:info, "AppServerLoad Report Unexpected Status: #{inspect status_code}")
         :error
 
       {:error, ereason} ->
-        ScoutApm.Logger.info("AppServerLoad Report Failed: Hackney Error: #{inspect ereason}")
+        ScoutApm.Logger.log(:info, "AppServerLoad Report Failed: Hackney Error: #{inspect ereason}")
         :error
 
       r ->
-        ScoutApm.Logger.info("AppServerLoad Report Failed: Unknown Hackney Error: #{inspect r}")
+        ScoutApm.Logger.log(:info, "AppServerLoad Report Failed: Unknown Hackney Error: #{inspect r}")
         :error
     end
   end

--- a/lib/scout_apm/config.ex
+++ b/lib/scout_apm/config.ex
@@ -45,7 +45,7 @@ defmodule ScoutApm.Config do
           {:ok, c} ->
             {:halt, c}
           :error ->
-            ScoutApm.Logger.info("Coercion of configuration #{key} failed. Ignoring")
+            ScoutApm.Logger.log(:info, "Coercion of configuration #{key} failed. Ignoring")
             {:cont, nil}
         end
       else

--- a/lib/scout_apm/internal/job_trace.ex
+++ b/lib/scout_apm/internal/job_trace.ex
@@ -149,7 +149,7 @@ defmodule ScoutApm.Internal.JobTrace do
     else
       # If we failed to lookup the percentile, just give back a 0 score.
       err ->
-        ScoutApm.Logger.debug("Failed to get percentile_score, error: #{err}")
+        ScoutApm.Logger.log(:debug, "Failed to get percentile_score, error: #{err}")
         0
     end
   end

--- a/lib/scout_apm/internal/web_trace.ex
+++ b/lib/scout_apm/internal/web_trace.ex
@@ -152,7 +152,7 @@ defmodule ScoutApm.Internal.WebTrace do
     else
       # If we failed to lookup the percentile, just give back a 0 score.
       err ->
-        ScoutApm.Logger.debug("Failed to get percentile_score, error: #{err}")
+        ScoutApm.Logger.log(:debug, "Failed to get percentile_score, error: #{err}")
         0
     end
   end

--- a/lib/scout_apm/logger.ex
+++ b/lib/scout_apm/logger.ex
@@ -5,17 +5,11 @@ defmodule ScoutApm.Logger do
   Defaults to pass-through to the built-in Logger, but checks first if
   the agent is set to monitor: false, or set to a higher log level.
 
-  This is a GenServer, to easily state on what log level we're at and if
-  something should be sent along.
-
-  This doesn't currently attempt any fancy log-message elimination
-  macros that the core Logger does.
+  Due to using Logger.log/2, ScoutApm.Logger calls will not be eliminated
+  at compile-time.
   """
-  use GenServer
 
   require Logger
-
-  @name __MODULE__
 
   @default_level :info
 
@@ -24,7 +18,7 @@ defmodule ScoutApm.Logger do
   # If you request to log a message at the left level, check if the
   # logger's current level is one of the right before letting it through
   #
-  # For instance, if you ScoutApm.Logger.warn("foo"), it should be
+  # For instance, if you ScoutApm.Logger.log(:warn, "foo"), it should be
   # printed if you're at warn, info, or debug levels
   #
   # Msg Lvl       Logger Lvl
@@ -36,62 +30,23 @@ defmodule ScoutApm.Logger do
   @warn_levels  [:debug, :info, :warn]
   @error_levels [:debug, :info, :warn, :error]
 
+  @log_levels %{
+    debug: @debug_levels,
+    info: @info_levels,
+    warn: @warn_levels,
+    error: @error_levels
+  }
 
-  ################
-  #  Client API  #
-  ################
-
-  def start_link(level \\ @default_level), do: GenServer.start_link(__MODULE__, level, name: @name)
-
-  def set_level(level), do: GenServer.cast(@name, {:set_level, level})
-  def set_enabled(value) when is_boolean(value), do: GenServer.cast(@name, {:set_enabled, value})
-  def enable!(), do: set_enabled(true)
-  def disable!(), do: set_enabled(false)
-
-  def reconfigure_from_config(), do: GenServer.cast(@name, :reconfigure_from_config)
-
-  def debug(msg, metadata \\ []), do: GenServer.cast(@name, {:debug, msg, metadata})
-  def info(msg, metadata \\ []), do: GenServer.cast(@name, {:info, msg, metadata})
-  def warn(msg, metadata \\ []), do: GenServer.cast(@name, {:warn, msg, metadata})
-  def error(msg, metadata \\ []), do: GenServer.cast(@name, {:error, msg, metadata})
-
-  def level(), do: GenServer.call(@name, :level)
-  def enabled?(), do: GenServer.call(@name, :enabled)
-
-  ################
-  #  Server API  #
-  ################
-  def init(level) do
-    state = %{level: level, enabled: true}
-    {:ok, state}
-  end
-
-  def handle_call(:level, _from, %{level: level} = state), do: {:reply, level, state}
-  def handle_call(:enabled, _from, %{enabled: enabled} = state), do: {:reply, enabled, state}
-
-  def handle_cast(:reconfigure_from_config, state) do
-    level = ScoutApm.Config.find(:log_level) || @default_level
+  def log(level, chardata_or_fun, metadata \\ []) when level in @valid_levels do
+    log_level = ScoutApm.Config.find(:log_level) || @default_level
     enabled = ScoutApm.Config.find(:monitor)
 
-    {
-      :noreply,
-      %{state |
-        level: level,
-        enabled: enabled
-      }
-    }
+    with {:ok, levels} <- enabled && Map.fetch(@log_levels, level),
+         true <- log_level in levels
+    do
+      Logger.log(level, chardata_or_fun, metadata)
+    else
+      _ -> :ok
+    end
   end
-
-  def handle_cast({:set_level, level}, state), do: %{state | level: level} |> noreply
-  def handle_cast({:set_enabled, value}, state), do: %{state | enabled: value} |> noreply
-
-  def handle_cast({msg_level, _, _}, %{enabled: false} = state) when msg_level in @valid_levels, do: noreply(state)
-  def handle_cast({:debug, msg, metadata}, %{level: level} = state) when level in @debug_levels, do: Logger.debug(msg, metadata) |> noreply(state)
-  def handle_cast({:info, msg, metadata},  %{level: level} = state) when level in @info_levels,  do: Logger.info(msg, metadata)  |> noreply(state)
-  def handle_cast({:warn, msg, metadata},  %{level: level} = state) when level in @warn_levels,  do: Logger.warn(msg, metadata)  |> noreply(state)
-  def handle_cast({:error, msg, metadata}, %{level: level} = state) when level in @error_levels, do: Logger.error(msg, metadata) |> noreply(state)
-  def handle_cast({msg_level, _, _}, state) when msg_level in @valid_levels, do: noreply(state)
-
-  defp noreply(state), do: {:noreply, state}
-  defp noreply(_, state), do: noreply(state)
 end

--- a/lib/scout_apm/logger.ex
+++ b/lib/scout_apm/logger.ex
@@ -40,8 +40,9 @@ defmodule ScoutApm.Logger do
   def log(level, chardata_or_fun, metadata \\ []) when level in @valid_levels do
     log_level = ScoutApm.Config.find(:log_level) || @default_level
     enabled = ScoutApm.Config.find(:monitor)
+    key = ScoutApm.Config.find(:key)
 
-    with {:ok, levels} <- enabled && Map.fetch(@log_levels, level),
+    with {:ok, levels} <- enabled && key && Map.fetch(@log_levels, level),
          true <- log_level in levels
     do
       Logger.log(level, chardata_or_fun, metadata)

--- a/lib/scout_apm/logger.ex
+++ b/lib/scout_apm/logger.ex
@@ -39,15 +39,20 @@ defmodule ScoutApm.Logger do
 
   def log(level, chardata_or_fun, metadata \\ []) when level in @valid_levels do
     log_level = ScoutApm.Config.find(:log_level) || @default_level
-    enabled = ScoutApm.Config.find(:monitor)
-    key = ScoutApm.Config.find(:key)
 
-    with {:ok, levels} <- enabled && key && Map.fetch(@log_levels, level),
+    with {:ok, levels} <- logging_enabled() && Map.fetch(@log_levels, level),
          true <- log_level in levels
     do
       Logger.log(level, chardata_or_fun, metadata)
     else
       _ -> :ok
     end
+  end
+
+  defp logging_enabled do
+    enabled = ScoutApm.Config.find(:monitor)
+    key = ScoutApm.Config.find(:key)
+
+    enabled && key
   end
 end

--- a/lib/scout_apm/plugs/controller_timer.ex
+++ b/lib/scout_apm/plugs/controller_timer.ex
@@ -56,7 +56,7 @@ defmodule ScoutApm.Plugs.ControllerTimer do
       ScoutApm.Context.add_user(:ip, remote_ip)
     rescue
       err ->
-        ScoutApm.Logger.debug("Failed adding IP context: #{inspect err}")
+        ScoutApm.Logger.log(:debug, "Failed adding IP context: #{inspect err}")
     end
   end
 end

--- a/lib/scout_apm/reporter.ex
+++ b/lib/scout_apm/reporter.ex
@@ -8,23 +8,23 @@ defmodule ScoutApm.Reporter do
 
     case {monitor, key} do
       {nil, nil} ->
-        ScoutApm.Logger.debug("Skipping Reporting, both monitor and key settings are missing")
+        ScoutApm.Logger.log(:debug, "Skipping Reporting, both monitor and key settings are missing")
         :ok
 
       {true, nil} ->
-        ScoutApm.Logger.debug("Skipping Reporting, key is nil")
+        ScoutApm.Logger.log(:debug, "Skipping Reporting, key is nil")
         :ok
 
       {true, ""} ->
-        ScoutApm.Logger.debug("Skipping Reporting, key is empty")
+        ScoutApm.Logger.log(:debug, "Skipping Reporting, key is empty")
         :ok
 
       {nil, _} ->
-        ScoutApm.Logger.debug("Skipping Reporting, monitor is nil")
+        ScoutApm.Logger.log(:debug, "Skipping Reporting, monitor is nil")
         :ok
 
       {false, _} ->
-        ScoutApm.Logger.debug("Skipping Reporting, monitor is false")
+        ScoutApm.Logger.log(:debug, "Skipping Reporting, monitor is false")
         :ok
 
       _ ->
@@ -47,27 +47,27 @@ defmodule ScoutApm.Reporter do
 
     header_list = headers()
 
-    ScoutApm.Logger.debug("Reporting ScoutAPM Payload to #{url}")
-    ScoutApm.Logger.debug("Payload Size. JSON: #{inspect :erlang.iolist_size(encoded_payload)}, Gzipped: #{inspect :erlang.iolist_size(gzipped_payload)}")
-    # ScoutApm.Logger.debug("JSON Payload: #{inspect encoded_payload}")
-    # ScoutApm.Logger.debug("Headers: #{inspect header_list}")
+    ScoutApm.Logger.log(:debug, "Reporting ScoutAPM Payload to #{url}")
+    ScoutApm.Logger.log(:debug, "Payload Size. JSON: #{inspect :erlang.iolist_size(encoded_payload)}, Gzipped: #{inspect :erlang.iolist_size(gzipped_payload)}")
+    # ScoutApm.Logger.log(:debug, "JSON Payload: #{inspect encoded_payload}")
+    # ScoutApm.Logger.log(:debug, "Headers: #{inspect header_list}")
 
     case :hackney.request(method, url, header_list , gzipped_payload, options) do
 
       {:ok, status_code, resp_headers, _client_ref} when status_code in @error_http_codes ->
-        ScoutApm.Logger.info("Reporting ScoutAPM Payload Failed with #{status_code}. Response Headers: #{inspect resp_headers}")
+        ScoutApm.Logger.log(:info, "Reporting ScoutAPM Payload Failed with #{status_code}. Response Headers: #{inspect resp_headers}")
 
       {:ok, status_code, _resp_headers, _client_ref} when status_code in @success_http_codes ->
-        ScoutApm.Logger.debug("Reporting ScoutAPM Payload Succeeded. Status: #{inspect status_code}")
+        ScoutApm.Logger.log(:debug, "Reporting ScoutAPM Payload Succeeded. Status: #{inspect status_code}")
 
       {:ok, status_code, _resp_headers, _client_ref} ->
-        ScoutApm.Logger.info("Reporting ScoutAPM Payload Unexpected Status: #{inspect status_code}")
+        ScoutApm.Logger.log(:info, "Reporting ScoutAPM Payload Unexpected Status: #{inspect status_code}")
 
       {:error, ereason} ->
-        ScoutApm.Logger.info("Reporting ScoutAPM Payload Failed: Hackney Error: #{inspect ereason}")
+        ScoutApm.Logger.log(:info, "Reporting ScoutAPM Payload Failed: Hackney Error: #{inspect ereason}")
 
       r ->
-        ScoutApm.Logger.info("Reporting ScoutAPM Payload Failed: Unknown Hackney Error: #{inspect r}")
+        ScoutApm.Logger.log(:info, "Reporting ScoutAPM Payload Failed: Unknown Hackney Error: #{inspect r}")
     end
 
     :ok

--- a/lib/scout_apm/store.ex
+++ b/lib/scout_apm/store.ex
@@ -28,7 +28,7 @@ defmodule ScoutApm.Store do
 
   def record_web_metric(%Metric{} = metric) do
     case Process.whereis(__MODULE__) do
-      nil -> ScoutApm.Logger.info("Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
+      nil -> ScoutApm.Logger.log(:info, "Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
       pid ->
         GenServer.cast(pid, {:record_web_metric, metric})
     end
@@ -36,7 +36,7 @@ defmodule ScoutApm.Store do
 
   def record_web_trace(%WebTrace{} = trace) do
     case Process.whereis(__MODULE__) do
-      nil -> ScoutApm.Logger.info("Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
+      nil -> ScoutApm.Logger.log(:info, "Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
       pid ->
         GenServer.cast(pid, {:record_web_trace, trace})
     end
@@ -44,7 +44,7 @@ defmodule ScoutApm.Store do
 
   def record_job_record(%JobRecord{} = job_record) do
     case Process.whereis(__MODULE__) do
-      nil -> ScoutApm.Logger.info("Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
+      nil -> ScoutApm.Logger.log(:info, "Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
       pid ->
         GenServer.cast(pid, {:record_job_record, job_record})
     end
@@ -52,7 +52,7 @@ defmodule ScoutApm.Store do
 
   def record_job_trace(%JobTrace{} = job_trace) do
     case Process.whereis(__MODULE__) do
-      nil -> ScoutApm.Logger.info("Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
+      nil -> ScoutApm.Logger.log(:info, "Couldn't find ScoutAPM Store Process. :scout_apm application is likely not started.")
       pid ->
         GenServer.cast(pid, {:record_job_trace, job_trace})
     end
@@ -61,7 +61,7 @@ defmodule ScoutApm.Store do
 
   def record_per_minute_histogram(key, duration) do
     case Process.whereis(__MODULE__) do
-      nil -> ScoutApm.Logger.info("Couldn't find worker!?")
+      nil -> ScoutApm.Logger.log(:info, "Couldn't find worker!?")
       pid ->
         GenServer.cast(pid, {:record_per_minute_histogram, key, duration})
     end
@@ -142,7 +142,7 @@ defmodule ScoutApm.Store do
 
   # Runs samplers, which should run once per-minute just before reporting.
   defp capture_samplers(reporting_period) do
-    ScoutApm.Logger.debug("Capturing samplers")
+    ScoutApm.Logger.log(:debug, "Capturing samplers")
     Enum.each([ScoutApm.Instruments.Samplers.Memory], fn sampler ->
       sampler.metrics |> Enum.each(fn metric ->
         StoreReportingPeriod.record_sampler_metric(reporting_period, metric)

--- a/lib/scout_apm/store_reporting_period.ex
+++ b/lib/scout_apm/store_reporting_period.ex
@@ -123,17 +123,17 @@ defmodule ScoutApm.StoreReportingPeriod do
         ScoredItemSet.to_list(state.job_traces, :without_scores)
       )
 
-      ScoutApm.Logger.debug("Reporting: Payload created with data from #{ScoutApm.Payload.total_call_count(payload)} requests.")
-      ScoutApm.Logger.debug("Payload #{inspect payload}")
+      ScoutApm.Logger.log(:debug, "Reporting: Payload created with data from #{ScoutApm.Payload.total_call_count(payload)} requests.")
+      ScoutApm.Logger.log(:debug, "Payload #{inspect payload}")
 
       encoded = ScoutApm.Payload.encode(payload)
 
-      ScoutApm.Logger.debug("Encoded Payload: #{inspect encoded}")
+      ScoutApm.Logger.log(:debug, "Encoded Payload: #{inspect encoded}")
 
       ScoutApm.Reporter.report(encoded)
     rescue
-      e in RuntimeError -> ScoutApm.Logger.info("Reporting runtime error: #{inspect e}")
-      e -> ScoutApm.Logger.info("Reporting other error: #{inspect e}")
+      e in RuntimeError -> ScoutApm.Logger.log(:info, "Reporting runtime error: #{inspect e}")
+      e -> ScoutApm.Logger.log(:info, "Reporting other error: #{inspect e}")
     end
   end
 

--- a/lib/scout_apm/tracing.ex
+++ b/lib/scout_apm/tracing.ex
@@ -133,7 +133,7 @@ defmodule ScoutApm.Tracing do
   # Deprecated!
   @spec instrument(String.t, String.t, any, function) :: any
   def instrument(type, name, opts \\ [], function) when is_function(function) do
-    ScoutApm.Logger.warn("#{__MODULE__}.instrument/4 is deprecated, use #{__MODULE__}.timing/4 instead")
+    ScoutApm.Logger.log(:warn, "#{__MODULE__}.instrument/4 is deprecated, use #{__MODULE__}.timing/4 instead")
     TrackedRequest.start_layer(type, name, opts)
     result = function.()
     TrackedRequest.stop_layer()

--- a/lib/scout_apm/watcher.ex
+++ b/lib/scout_apm/watcher.ex
@@ -19,7 +19,7 @@ defmodule ScoutApm.Watcher do
 
   def init(mod) do
     Process.monitor(mod)
-    ScoutApm.Logger.info("Setup ScoutApm.Watcher on #{inspect mod}")
+    ScoutApm.Logger.log(:info, "Setup ScoutApm.Watcher on #{inspect mod}")
     {:ok, :ok}
   end
 
@@ -28,7 +28,7 @@ defmodule ScoutApm.Watcher do
   # `Store` crashes, both the supervisor and this watcher get notified,
   # but the supervisor will shut down and restart this process as well.
   def handle_info({:DOWN, _, _, {what, _node}, reason}, state) do
-    ScoutApm.Logger.info("ScoutAPM Watcher: #{inspect what} Stopped: #{inspect reason}")
+    ScoutApm.Logger.log(:info, "ScoutAPM Watcher: #{inspect what} Stopped: #{inspect reason}")
     {:stop, :normal, state}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -30,9 +30,9 @@ defmodule ScoutApm.Mixfile do
     [
       {:plug, "~>1.0"},
 
-      # We only use `encode!(map)`, which has existed since the start of poison,
+      # We only use `encode!(map) and decode(map)`, which have existed since the start of poison,
       # so don't restrict the version of poison here. In the unlikely case that
-      # the encode! function is removed in a new version, we'll have to revisit.
+      # either function is removed in a new version, we'll have to revisit.
       {:poison, ">= 0.0.0"},
 
       # We only use `request/5` from hackney, which hasn't changed in the 1.0 line.

--- a/test/scout_apm/config_test.exs
+++ b/test/scout_apm/config_test.exs
@@ -1,5 +1,5 @@
 defmodule ScoutApm.ConfigTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   test "find/1 with plain value" do
     Mix.Config.persist(scout_apm: [key: "abc123"])
@@ -7,6 +7,7 @@ defmodule ScoutApm.ConfigTest do
     key = ScoutApm.Config.find(:key)
 
     assert key == "abc123"
+    Application.delete_env(:scout_apm, :key)
   end
 
   test "find/1 with application defined ENV variable" do

--- a/test/scout_apm/internal/job_record_test.exs
+++ b/test/scout_apm/internal/job_record_test.exs
@@ -1,8 +1,6 @@
 defmodule ScoutApm.Internal.JobRecordTest do
   use ExUnit.Case, async: true
 
-  alias ScoutApm.Internal.JobRecord
-
   describe "new/0" do
     test "creating" do
 

--- a/test/scout_apm/logger_test.exs
+++ b/test/scout_apm/logger_test.exs
@@ -57,4 +57,14 @@ defmodule ScoutApm.LoggerTest do
     Application.delete_env(:scout_apm, :log_level)
     Application.delete_env(:scout_apm, :key)
   end
+
+  test "never logs if key is not configured" do
+    Mix.Config.persist(scout_apm: [monitor: true, key: nil, log_level: :debug])
+    assert capture_log(fn ->
+      ScoutApm.Logger.log(:error, "Log")
+    end) == ""
+
+    Application.delete_env(:scout_apm, :monitor)
+    Application.delete_env(:scout_apm, :log_level)
+  end
 end

--- a/test/scout_apm/logger_test.exs
+++ b/test/scout_apm/logger_test.exs
@@ -1,0 +1,60 @@
+defmodule ScoutApm.LoggerTest do
+  use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
+
+  test "always logs errors" do
+    Mix.Config.persist(scout_apm: [monitor: true, key: "abc123"])
+
+    Application.put_env(:scout_apm, :log_level, :debug)
+    assert capture_log(fn ->
+      ScoutApm.Logger.log(:error, "Debug Log")
+    end) =~ "Debug Log"
+
+    Application.put_env(:scout_apm, :log_level, :info)
+    assert capture_log(fn ->
+      ScoutApm.Logger.log(:error, "Info Log")
+    end) =~ "Info Log"
+
+    Application.put_env(:scout_apm, :log_level, :warn)
+    assert capture_log(fn ->
+      ScoutApm.Logger.log(:error, "Warn Log")
+    end) =~ "Warn Log"
+
+    Application.put_env(:scout_apm, :log_level, :error)
+    assert capture_log(fn ->
+      ScoutApm.Logger.log(:error, "Error Log")
+    end) =~ "Error Log"
+
+    Application.delete_env(:scout_apm, :monitor)
+    Application.delete_env(:scout_apm, :log_level)
+    Application.delete_env(:scout_apm, :key)
+  end
+
+  test "only logs debug in debug level" do
+    Mix.Config.persist(scout_apm: [monitor: true, key: "abc123"])
+
+    Application.put_env(:scout_apm, :log_level, :debug)
+    assert capture_log(fn ->
+      ScoutApm.Logger.log(:error, "Debug Log")
+    end) =~ "Debug Log"
+
+    Application.put_env(:scout_apm, :log_level, :info)
+    assert capture_log(fn ->
+      ScoutApm.Logger.log(:debug, "Info Log")
+    end) == ""
+
+    Application.put_env(:scout_apm, :log_level, :warn)
+    assert capture_log(fn ->
+      ScoutApm.Logger.log(:debug, "Warn Log")
+    end) == ""
+
+    Application.put_env(:scout_apm, :log_level, :error)
+    assert capture_log(fn ->
+      ScoutApm.Logger.log(:debug, "Error Log")
+    end) == ""
+
+    Application.delete_env(:scout_apm, :monitor)
+    Application.delete_env(:scout_apm, :log_level)
+    Application.delete_env(:scout_apm, :key)
+  end
+end

--- a/test/scout_apm/metric_set_test.exs
+++ b/test/scout_apm/metric_set_test.exs
@@ -1,6 +1,5 @@
 defmodule ScoutApm.MetricSetTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureLog
 
   alias ScoutApm.MetricSet
   alias ScoutApm.Internal.Metric


### PR DESCRIPTION
Closes #43 

This also replaces the current `ScoutApm.Logger` GenServer with a direct module that can depend on the `Elixir.Logger` backpressure mechanisms. Like the GenServer version, this Logger will not have the log calls compiled out.