### PR TITLE
setup cache before starting supervisor

### DIFF
--- a/lib/scout_apm/application.ex
+++ b/lib/scout_apm/application.ex
@@ -16,12 +16,12 @@ defmodule ScoutApm.Application do
       worker(ScoutApm.Watcher, [ScoutApm.PersistentHistogram], id: :histogram_watcher),
     ]
 
+    ScoutApm.Cache.setup()
+
     # Stupidly persistent. Really high max restarts for debugging
     # opts = [strategy: :one_for_all, max_restarts: 10000000, max_seconds: 1, name: ScoutApm.Supervisor]
     opts = [strategy: :one_for_all, name: ScoutApm.Supervisor]
     {:ok, pid} = Supervisor.start_link(children, opts)
-
-    ScoutApm.Cache.setup()
 
     ScoutApm.Watcher.start_link(ScoutApm.Supervisor)
 


### PR DESCRIPTION
This fixes an error that pops up when testing apps using this library that happens because `ScoutApm.ApplicationLoadNotification` tries to access the ets table created by the cache before the table is set up.

```
[error] GenServer ScoutApm.ApplicationLoadNotification terminating
** (ArgumentError) argument error
    (stdlib) :ets.lookup(:scout_cache, :hostname)
    (scout_apm) lib/scout_apm/cache.ex:15: ScoutApm.Cache.hostname/0
    (scout_apm) lib/scout_apm/payload/app_server_load.ex:16: ScoutApm.Payload.AppServerLoad.new/0
    (scout_apm) lib/scout_apm/application_load_notification.ex:33: ScoutApm.ApplicationLoadNotification.handle_cast/2
    (stdlib) gen_server.erl:616: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:686: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message: {:"$gen_cast", {:run, [retries: 3]}}
```