### PR TITLE
Add Deploy Detection & Tracking

### DIFF
--- a/lib/scout_apm/cache.ex
+++ b/lib/scout_apm/cache.ex
@@ -6,7 +6,12 @@ defmodule ScoutApm.Cache do
     :ets.new(@table_name, [:named_table, :set, :protected, read_concurrency: true])
 
     :ets.insert(@table_name, {:hostname, determine_hostname()})
+    :ets.insert(@table_name, {:git_sha, determine_git_sha()})
   end
+
+  ######################################
+  #  Public Functions to Lookup Values #
+  ######################################
 
   def hostname do
     case :ets.lookup(@table_name, :hostname) do
@@ -14,6 +19,17 @@ defmodule ScoutApm.Cache do
       _ -> nil
     end
   end
+
+  def git_sha do
+    case :ets.lookup(@table_name, :git_sha) do
+      [{:git_sha, hostname}] -> hostname
+      _ -> nil
+    end
+  end
+
+  ########################
+  #  Hostname Detection  #
+  ########################
 
   defp determine_hostname do
     case heroku_hostname() do
@@ -29,5 +45,27 @@ defmodule ScoutApm.Cache do
   defp inet_hostname do
     {:ok, hostname} = :inet.gethostname()
     to_string(hostname)
+  end
+
+  #######################
+  #  Git SHA Detection  #
+  #######################
+
+  # Lookup via explicitly configured values, then if not, fall back to a heroku
+  # setting, then ... nil
+  def determine_git_sha do
+    case configured_sha() do
+      sha when is_binary(sha) -> sha
+      _ -> heroku_sha()
+    end
+  end
+
+  defp heroku_sha do
+    System.get_env("HEROKU_SLUG_COMMIT")
+  end
+
+  # Looks in all normal configuration locations (Application, {:system, ENV}, ENV)
+  defp configured_sha do
+    ScoutApm.Config.find(:revision_sha)
   end
 end

--- a/lib/scout_apm/internal/job_trace.ex
+++ b/lib/scout_apm/internal/job_trace.ex
@@ -22,6 +22,7 @@ defmodule ScoutApm.Internal.JobTrace do
     :metrics,
 
     :hostname,
+    :git_sha,
     :score,
   ]
 
@@ -38,11 +39,12 @@ defmodule ScoutApm.Internal.JobTrace do
     exclusive_time: Duration.t,
     metrics: MetricSet.t,
     hostname: String.t,
+    git_sha: String.t,
     score: number(),
   }
 
-  @spec new(String.t, String.t, any, list(Context.t), Duration.t, Duration.t, MetricSet.t, String.t) :: t
-  def new(queue_name, job_name, time, contexts, total_time, exclusive_time, metrics, hostname) do
+  @spec new(String.t, String.t, any, list(Context.t), Duration.t, Duration.t, MetricSet.t, String.t, String.t | nil) :: t
+  def new(queue_name, job_name, time, contexts, total_time, exclusive_time, metrics, hostname, git_sha) do
     %__MODULE__{
       queue_name: queue_name,
       job_name: job_name,
@@ -52,6 +54,7 @@ defmodule ScoutApm.Internal.JobTrace do
       exclusive_time: exclusive_time,
       metrics: metrics,
       hostname: hostname,
+      git_sha: git_sha,
 
       # TODO: Update the trace w/ the score?
       score: 0
@@ -67,6 +70,7 @@ defmodule ScoutApm.Internal.JobTrace do
     queue_name = "default"
     time = DateTime.utc_now() |> DateTime.to_iso8601()
     hostname = ScoutApm.Cache.hostname()
+    git_sha = ScoutApm.Cache.git_sha()
     contexts = tracked_request.contexts
     metric_set = create_trace_metrics(
       root_layer,
@@ -81,7 +85,8 @@ defmodule ScoutApm.Internal.JobTrace do
       duration,
       duration, # exclusive time isn't used?
       metric_set,
-      hostname
+      hostname,
+      git_sha
     )
   end
 

--- a/lib/scout_apm/internal/web_trace.ex
+++ b/lib/scout_apm/internal/web_trace.ex
@@ -17,7 +17,8 @@ defmodule ScoutApm.Internal.WebTrace do
     :metrics,
     :uri,
     :time,
-    :hostname, # hack - we need to reset these server side.
+    :hostname,
+    :git_sha,
     :contexts,
 
     # TODO: Does anybody ever set this Score field?
@@ -32,12 +33,13 @@ defmodule ScoutApm.Internal.WebTrace do
     uri: nil | String.t,
     time: any,
     hostname: String.t,
+    git_sha: String.t,
     contexts: Context.t,
     score: number(),
   }
 
-  # @spec new(String.t, String.t, Duration.t, list(Metric.t), String.t, Context.t, any, String.t) :: t
-  def new(type, name, duration, metrics, uri, contexts, time, hostname) do
+  # @spec new(String.t, String.t, Duration.t, list(Metric.t), String.t, Context.t, any, String.t, String.t | nil) :: t
+  def new(type, name, duration, metrics, uri, contexts, time, hostname, git_sha) do
     %__MODULE__{
       type: type,
       name: name,
@@ -46,6 +48,7 @@ defmodule ScoutApm.Internal.WebTrace do
       uri: uri,
       time: time,
       hostname: hostname,
+      git_sha: git_sha,
       contexts: contexts,
 
       # TODO: Store the trace's own score
@@ -65,6 +68,7 @@ defmodule ScoutApm.Internal.WebTrace do
 
     time = DateTime.utc_now() |> DateTime.to_iso8601()
     hostname = ScoutApm.Cache.hostname()
+    git_sha = ScoutApm.Cache.git_sha()
 
     # Metrics scoped & stuff. Distinguished by type, name, scope, desc
     metric_set = create_trace_metrics(
@@ -72,7 +76,7 @@ defmodule ScoutApm.Internal.WebTrace do
       ScopeStack.new(),
       MetricSet.new(%{compare_desc: true, collapse_all: true}))
 
-    new(root_layer.type, root_layer.name, duration, MetricSet.to_list(metric_set), uri, contexts, time, hostname)
+    new(root_layer.type, root_layer.name, duration, MetricSet.to_list(metric_set), uri, contexts, time, hostname, git_sha)
   end
 
   # Each layer creates two Trace metrics:

--- a/lib/scout_apm/payload/app_server_load.ex
+++ b/lib/scout_apm/payload/app_server_load.ex
@@ -14,11 +14,11 @@ defmodule ScoutApm.Payload.AppServerLoad do
       libraries:            libraries(),
       application_name:     ScoutApm.Config.find(:name),
       hostname:             ScoutApm.Cache.hostname(),
+      git_sha:              ScoutApm.Cache.git_sha(),
       # framework:          ScoutApm::Environment.instance.framework_integration.human_name,
       # framework_version:  ScoutApm::Environment.instance.framework_integration.version,
       # environment:        ScoutApm::Environment.instance.framework_integration.env,
       # paas:               ScoutApm::Environment.instance.platform_integration.name,
-      # git_sha:            ScoutApm::Environment.instance.git_revision.sha
     }
   end
 

--- a/lib/scout_apm/payload/slow_jobs.ex
+++ b/lib/scout_apm/payload/slow_jobs.ex
@@ -16,6 +16,7 @@ defmodule ScoutApm.Payload.SlowJobs do
       exclusive_time: Duration.as(job_trace.exclusive_time, :seconds),
 
       hostname: job_trace.hostname,
+      git_sha: job_trace.git_sha,
       metrics: ScoutApm.Payload.NewMetrics.new(job_trace.metrics),
       context: ScoutApm.Payload.Context.new(job_trace.contexts),
 
@@ -26,7 +27,6 @@ defmodule ScoutApm.Payload.SlowJobs do
       #
       # allocation_metrics: MetricsToJsonSerializer.new(job.allocation_metrics).as_json, # New style of metrics
       # truncated_metrics: job.truncated_metrics,
-      # git_sha: job.git_sha,
       # allocations: job.allocations,
       # mem_delta: job.mem_delta,
       # seconds_since_startup: job.seconds_since_startup,

--- a/lib/scout_apm/payload/slow_transaction.ex
+++ b/lib/scout_apm/payload/slow_transaction.ex
@@ -45,8 +45,8 @@ defmodule ScoutApm.Payload.SlowTransaction do
       allocations: 0,
       seconds_since_startup: 0,
 
-      hostname: ScoutApm.Cache.hostname(),
-      git_sha: "",
+      hostname: trace.hostname,
+      git_sha: trace.git_sha,
       truncated_metrics: %{},
     }
   end

--- a/test/scout_apm/cache_test.exs
+++ b/test/scout_apm/cache_test.exs
@@ -1,7 +1,33 @@
 defmodule ScoutApm.CacheTest do
   use ExUnit.Case
 
+  ##############
+  #  Hostname  #
+  ##############
+
   test "stores hostname" do
     assert is_binary(ScoutApm.Cache.hostname())
+  end
+
+  #############
+  #  Git SHA  #
+  #############
+
+  test "determines git sha from Heroku ENV" do
+    System.put_env("HEROKU_SLUG_COMMIT", "abcd")
+    assert ScoutApm.Cache.determine_git_sha() == "abcd"
+    System.delete_env("HEROKU_SLUG_COMMIT")
+  end
+
+  test "determines git sha from SCOUT_REVISION_SHA env" do
+    System.put_env("SCOUT_REVISION_SHA", "1234")
+    assert ScoutApm.Cache.determine_git_sha() == "1234"
+    System.delete_env("SCOUT_REVISION_SHA")
+  end
+
+  test "determines git sha from revision_sha application setting" do
+    Mix.Config.persist(scout_apm: [revision_sha: "abc123"])
+    assert ScoutApm.Cache.determine_git_sha() == "abc123"
+    Application.delete_env(:scout_apm, :revision_sha)
   end
 end


### PR DESCRIPTION
* Adds detection of the running Git SHA if it can be detected. Currently this looks
  at Heroku's env var, or a customer-set revision_sha setting (same as any other config).
* Connects the detected SHA to the appropriate payloads to trigger server-side
  logic of deploy tracking.
* Connects the detected SHA to individual traces, they it can be found in the
  Context pane of the trace view in the Web UI