### PR TITLE
rename *seconds to *second, move System.cwd to File.cwd to fix all deprecations on 1.8.0

### DIFF
--- a/lib/scout_apm/instruments/ecto_logger.ex
+++ b/lib/scout_apm/instruments/ecto_logger.ex
@@ -86,7 +86,7 @@ defmodule ScoutApm.Instruments.EctoLogger do
   end
 
   def query_time(%{query_time: query_time}) when is_integer(query_time) do
-    microtime = System.convert_time_unit(query_time, :native, :microseconds)
+    microtime = System.convert_time_unit(query_time, :native, :microsecond)
     {:ok, ScoutApm.Internal.Duration.new(microtime, :microseconds)}
   end
 

--- a/lib/scout_apm/internal/layer.ex
+++ b/lib/scout_apm/internal/layer.ex
@@ -41,9 +41,9 @@ defmodule ScoutApm.Internal.Layer do
   #  Construction  #
   ##################
 
-  @spec new(map) :: __MODULE__.t
+  @spec new(map) :: __MODULE__.t()
   def new(%{type: type, opts: opts} = data) do
-    started_at = data[:started_at] || System.monotonic_time(:microseconds)
+    started_at = data[:started_at] || System.monotonic_time(:microsecond)
     name = data[:name]
     scopable = Keyword.get(opts, :scopable, true)
 
@@ -63,7 +63,8 @@ defmodule ScoutApm.Internal.Layer do
   def update_name(layer, nil), do: layer
   def update_name(layer, name), do: %{layer | name: name}
 
-  def update_stopped_at(layer), do: update_stopped_at(layer, System.monotonic_time(:microseconds))
+  def update_stopped_at(layer), do: update_stopped_at(layer, System.monotonic_time(:microsecond))
+
   def update_stopped_at(layer, stopped_at) do
     %{layer | stopped_at: stopped_at}
   end

--- a/lib/scout_apm/payload/metadata.ex
+++ b/lib/scout_apm/payload/metadata.ex
@@ -11,14 +11,13 @@ defmodule ScoutApm.Payload.Metadata do
 
   def new(timestamp) do
     %__MODULE__{
-      app_root: File.cwd(),
+      app_root: File.cwd!(),
       unique_id: ScoutApm.Utils.random_string(20),
       payload_version: 1,
       agent_version: ScoutApm.Utils.agent_version(),
       agent_time: timestamp |> DateTime.from_naive!("Etc/UTC") |> DateTime.to_iso8601(),
-      agent_pid: System.get_pid() |> String.to_integer,
-      platform: "elixir",
+      agent_pid: System.get_pid() |> String.to_integer(),
+      platform: "elixir"
     }
   end
-
 end

--- a/lib/scout_apm/payload/metadata.ex
+++ b/lib/scout_apm/payload/metadata.ex
@@ -11,7 +11,7 @@ defmodule ScoutApm.Payload.Metadata do
 
   def new(timestamp) do
     %__MODULE__{
-      app_root: System.cwd(),
+      app_root: File.cwd(),
       unique_id: ScoutApm.Utils.random_string(20),
       payload_version: 1,
       agent_version: ScoutApm.Utils.agent_version(),

--- a/test/scout_apm/payload/metadata_test.exs
+++ b/test/scout_apm/payload/metadata_test.exs
@@ -1,0 +1,19 @@
+defmodule ScoutApm.Payload.MetadataTest do
+  use ExUnit.Case, async: true
+
+  alias ScoutApm.Payload.Metadata
+
+  describe "new/1" do
+    test "creating a metadata struct with a timestamp" do
+      {:ok, app_root} = File.cwd()
+      timestamp = DateTime.utc_now()
+
+      assert %ScoutApm.Payload.Metadata{
+               agent_version: "0.4.9",
+               app_root: ^app_root,
+               payload_version: 1,
+               platform: "elixir"
+             } = Metadata.new(timestamp)
+    end
+  end
+end

--- a/test/scout_apm/payload/metadata_test.exs
+++ b/test/scout_apm/payload/metadata_test.exs
@@ -6,12 +6,13 @@ defmodule ScoutApm.Payload.MetadataTest do
   describe "new/1" do
     test "creating a metadata struct with a timestamp" do
       {:ok, app_root} = File.cwd()
-      timestamp = DateTime.utc_now()
+      {:ok, timestamp} = NaiveDateTime.new(2018, 1, 1, 1, 5, 3)
 
       assert %ScoutApm.Payload.Metadata{
                agent_version: "0.4.9",
                app_root: ^app_root,
                payload_version: 1,
+               agent_time: "2018-01-01T01:05:03Z",
                platform: "elixir"
              } = Metadata.new(timestamp)
     end


### PR DESCRIPTION
Ran the tests with 1.8.0-rc.1 and got some deprecation warnings, this should fix them.