### PR TITLE
fix deprecation warning on NaiveDateTime.diff/3 use singular :second

### DIFF
--- a/lib/scout_apm/store_reporting_period.ex
+++ b/lib/scout_apm/store_reporting_period.ex
@@ -94,7 +94,7 @@ defmodule ScoutApm.StoreReportingPeriod do
     t = Agent.get(pid, fn state -> state.time end)
     now = NaiveDateTime.utc_now()
 
-    diff = NaiveDateTime.diff(now, t, :seconds)
+    diff = NaiveDateTime.diff(now, t, :second)
 
     if diff > @reporting_age do
       :ready


### PR DESCRIPTION
Got this deprecation warning on Elixir 1.8.1