### PR TITLE
upgrade telemetry

### DIFF
--- a/lib/scout_apm/instruments/ecto_telemetry.ex
+++ b/lib/scout_apm/instruments/ecto_telemetry.ex
@@ -14,11 +14,10 @@ if Code.ensure_loaded?(Telemetry) do
         |> Enum.map(&(&1 |> Macro.underscore() |> String.to_atom()))
         |> Kernel.++([:query])
 
-      Telemetry.attach(
+      :telemetry.attach(
         "scout-ecto-query-handler",
         query_event,
-        ScoutApm.Instruments.EctoTelemetry,
-        :handle_event,
+        &ScoutApm.Instruments.EctoTelemetry.handle_event/4,
         nil
       )
     end

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule ScoutApm.Mixfile do
       {:hackney, "~> 1.0"},
 
       {:approximate_histogram, "~>0.1.1"},
-      {:telemetry, "~> 0.2.0", optional: true},
+      {:telemetry, "~> 0.3.0", optional: true},
 
       #########################
       # Dev & Testing Deps

--- a/mix.lock
+++ b/mix.lock
@@ -26,5 +26,5 @@
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], []},
   "slime": {:hex, :slime, "0.16.0", "4f9c677ca37b2817cd10422ecb42c524fe904d3630acf242b81dfe189900272a", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
-  "telemetry": {:hex, :telemetry, "0.2.0", "5b40caa3efe4deb30fb12d7cd8ed4f556f6d6bd15c374c2366772161311ce377", [:mix], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.3.0", "099a7f3ce31e4780f971b4630a3c22ec66d22208bc090fe33a2a3a6a67754a73", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
ecto_sql bumped the version of telemetry that included some breaking changes:

https://github.com/elixir-ecto/ecto_sql/blob/master/CHANGELOG.md#enhancements-2
https://github.com/beam-telemetry/telemetry/blob/master/CHANGELOG.md#030

There's also a `0.4.0` out, but doesn't look like Ecto has a release that includes it (yet)