### PR TITLE
Don't rely on prefix of Telemetry when pattern matching the handler

### DIFF
--- a/lib/scout_apm/instruments/ecto_telemetry.ex
+++ b/lib/scout_apm/instruments/ecto_telemetry.ex
@@ -22,8 +22,10 @@ if Code.ensure_loaded?(Telemetry) do
       )
     end
 
-    def handle_event([_app, _repo, :query], _value, metadata, _config) do
-      ScoutApm.Instruments.EctoLogger.record(metadata)
+    def handle_event(query_event, _value, metadata, _config) when is_list(query_event) do
+      if :query == List.last(query_event) do
+        ScoutApm.Instruments.EctoLogger.record(metadata)
+      end
     end
   end
 end


### PR DESCRIPTION
This allows an arbitrary nesting of the module without breaking the
handle_event pattern match. Just ignores the data since we weren't using
it anyway.

We can't simply change the naming of the query_event list because the Ecto
side emits events under the exact name. Search on `telemetry_prefix` in docs
if you want to see more

Fixes #76