### PR TITLE
update telemetry to latest version 0.4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,9 +37,8 @@ defmodule ScoutApm.Mixfile do
 
       # We only use `request/5` from hackney, which hasn't changed in the 1.0 line.
       {:hackney, "~> 1.0"},
-
       {:approximate_histogram, "~>0.1.1"},
-      {:telemetry, "~> 0.3.0", optional: true},
+      {:telemetry, "~> 0.4.0", optional: true},
 
       #########################
       # Dev & Testing Deps

--- a/mix.lock
+++ b/mix.lock
@@ -26,5 +26,5 @@
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], []},
   "slime": {:hex, :slime, "0.16.0", "4f9c677ca37b2817cd10422ecb42c524fe904d3630acf242b81dfe189900272a", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
-  "telemetry": {:hex, :telemetry, "0.3.0", "099a7f3ce31e4780f971b4630a3c22ec66d22208bc090fe33a2a3a6a67754a73", [:rebar3], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
In my app I updated to Ecto 3.1.0, which uses telemetry 0.4.0. As a result mix finds a conflict in my dependency tree. Thought this might be useful for others too.. 