### PR TITLE
Update CoreAgent version to 1.2.6, with several bug fixes

### DIFF
--- a/lib/scout_apm/config/defaults.ex
+++ b/lib/scout_apm/config/defaults.ex
@@ -9,7 +9,7 @@ defmodule ScoutApm.Config.Defaults do
       core_agent_dir: "/tmp/scout_apm_core",
       core_agent_download: true,
       core_agent_launch: true,
-      core_agent_version: "v1.2.4",
+      core_agent_version: "v1.2.6",
       core_agent_tcp_ip: {127, 0, 0, 1},
       core_agent_tcp_port: 9000,
       collector_module: ScoutApm.Core.AgentManager,


### PR DESCRIPTION
(from CA's changelog)

[1.2.6] 2019-12-03

Fixed:

* Use SQL derived names in SpanTraces (#97)

[1.2.5] 2019-12-02

Added:

* Autoclose running spans when request finishes (#93)
* Rate Limit AppServerLoad metadata (#94)
* Add `language_version` key to AppServerLoad metadata (#95)

Fixed:

* Prevent errors if AppServerLoad metadata is not set (#92)