### PR TITLE
Add option to control whether the app name is trimmed from controllers

### DIFF
--- a/lib/scout_apm/config/defaults.ex
+++ b/lib/scout_apm/config/defaults.ex
@@ -13,7 +13,6 @@ defmodule ScoutApm.Config.Defaults do
       core_agent_tcp_ip: {127, 0, 0, 1},
       core_agent_tcp_port: 9000,
       collector_module: ScoutApm.Core.AgentManager,
-      trim_app_module_name: true,
       download_url:
         "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release"
     }

--- a/lib/scout_apm/config/defaults.ex
+++ b/lib/scout_apm/config/defaults.ex
@@ -13,6 +13,7 @@ defmodule ScoutApm.Config.Defaults do
       core_agent_tcp_ip: {127, 0, 0, 1},
       core_agent_tcp_port: 9000,
       collector_module: ScoutApm.Core.AgentManager,
+      trim_app_module_name: true,
       download_url:
         "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release"
     }

--- a/lib/scout_apm/instrumentation.ex
+++ b/lib/scout_apm/instrumentation.ex
@@ -1,8 +1,10 @@
 defmodule ScoutApm.Instrumentation do
-  defmacro __using__(_arg) do
+  defmacro __using__(opts) do
+    timer_options = Keyword.take(opts, [:include_application_name])
+
     quote do
       plug(ScoutApm.DevTrace.Plug)
-      plug(ScoutApm.Plugs.ControllerTimer)
+      plug(ScoutApm.Plugs.ControllerTimer, unquote(timer_options))
     end
   end
 end

--- a/lib/scout_apm/instruments/eex_engine.ex
+++ b/lib/scout_apm/instruments/eex_engine.ex
@@ -25,7 +25,7 @@ defmodule ScoutApm.Instruments.EExEngine do
     quote do
       require ScoutApm.Tracing
 
-      ScoutApm.Tracing.timing("EEx", unquote(scout_name), [scopable: !unquote(is_layout)],
+      ScoutApm.Tracing.timing("EEx", unquote(path), [scopable: !unquote(is_layout)],
         do: unquote(quoted_template)
       )
     end

--- a/lib/scout_apm/instruments/exs_engine.ex
+++ b/lib/scout_apm/instruments/exs_engine.ex
@@ -3,21 +3,11 @@ defmodule ScoutApm.Instruments.ExsEngine do
 
   # TODO: Make this name correctly for other template locations
   def compile(path, name) do
-    # web/templates/page/index.html.eex
-    scout_name =
-      path
-      # [web, templates, page, index.html.eex]
-      |> String.split("/")
-      # [page, index.html.eex]
-      |> Enum.drop(2)
-      # "page/index.html.eex"
-      |> Enum.join("/")
-
     quoted_template = Phoenix.Template.ExsEngine.compile(path, name)
 
     quote do
       require ScoutApm.Tracing
-      ScoutApm.Tracing.timing("Exs", unquote(scout_name), do: unquote(quoted_template))
+      ScoutApm.Tracing.timing("Exs", unquote(path), do: unquote(quoted_template))
     end
   end
 end

--- a/lib/scout_apm/instruments/slime_engine.ex
+++ b/lib/scout_apm/instruments/slime_engine.ex
@@ -26,7 +26,7 @@ if Code.ensure_loaded?(PhoenixSlime) do
       quote do
         require ScoutApm.Tracing
 
-        ScoutApm.Tracing.timing("Slime", unquote(scout_name), [scopable: !unquote(is_layout)],
+        ScoutApm.Tracing.timing("Slime", unquote(path), [scopable: !unquote(is_layout)],
           do: unquote(quoted_template)
         )
       end

--- a/lib/scout_apm/plugs/controller_timer.ex
+++ b/lib/scout_apm/plugs/controller_timer.ex
@@ -65,11 +65,8 @@ defmodule ScoutApm.Plugs.ControllerTimer do
     action_name = conn.private[:phoenix_action]
 
     conn.private[:phoenix_controller]
-    # String looks like "Elixir.TestappPhoenix.PageController"
-    |> to_string
-    # Split into parts
-    |> String.split(".")
-    # Remove Elixir and app module name (if configured)
+    |> Module.split()
+    # Remove app module name (if configured)
     |> Enum.drop(num_parts_to_drop())
     |> Enum.join(".")
     # Append action
@@ -126,6 +123,6 @@ defmodule ScoutApm.Plugs.ControllerTimer do
   end
 
   defp num_parts_to_drop do
-    if Config.find(:trim_app_module_name), do: 2, else: 1
+    if Config.find(:trim_app_module_name), do: 1, else: 0
   end
 end

--- a/lib/scout_apm/plugs/controller_timer.ex
+++ b/lib/scout_apm/plugs/controller_timer.ex
@@ -1,6 +1,6 @@
 defmodule ScoutApm.Plugs.ControllerTimer do
   alias ScoutApm.Internal.Layer
-  alias ScoutApm.{Context, TrackedRequest}
+  alias ScoutApm.{Context, TrackedRequest, Config}
   @queue_headers ~w(x-queue-start x-request-start)
 
   def init(default), do: default
@@ -54,20 +54,26 @@ defmodule ScoutApm.Plugs.ControllerTimer do
 
   def maybe_mark_error(conn), do: conn
 
-  # Takes a connection, extracts the phoenix controller & action, then manipulates & cleans it up.
-  # Returns a string like "PageController#index"
+  @doc """
+  Takes a connection, extracts the phoenix controller & action, then manipulates
+  & cleans it up.
+
+  Returns a string like "PageController#index"
+  """
+  @spec action_name(Plug.Conn.t()) :: String.t()
   def action_name(conn) do
-    controller_name = conn.private[:phoenix_controller]
     action_name = conn.private[:phoenix_action]
 
-    # a string like "Elixir.TestappPhoenix.PageController#index"
-    "#{controller_name}##{action_name}"
-    # Split into a list
+    conn.private[:phoenix_controller]
+    # String looks like "Elixir.TestappPhoenix.PageController"
+    |> to_string
+    # Split into parts
     |> String.split(".")
-    # drop "Elixir.TestappPhoenix", leaving just ["PageController#index"]
-    |> Enum.drop(2)
-    # Probably just "joining" a 1 elem array, but recombine this way anyway in case of periods
+    # Remove Elixir and app module name (if configured)
+    |> Enum.drop(num_parts_to_drop())
     |> Enum.join(".")
+    # Append action
+    |> String.replace_suffix("", "##{action_name}")
   end
 
   defp add_ip_context(conn) do
@@ -117,5 +123,9 @@ defmodule ScoutApm.Plugs.ControllerTimer do
 
   defp parse_request_start_time(queue_start_ms) do
     Integer.parse(queue_start_ms)
+  end
+
+  defp num_parts_to_drop do
+    if Config.find(:trim_app_module_name), do: 2, else: 1
   end
 end

--- a/lib/scout_apm/plugs/controller_timer.ex
+++ b/lib/scout_apm/plugs/controller_timer.ex
@@ -66,8 +66,7 @@ defmodule ScoutApm.Plugs.ControllerTimer do
 
     conn.private[:phoenix_controller]
     |> Module.split()
-    # Remove app module name (if configured)
-    |> Enum.drop(num_parts_to_drop())
+    |> trim_app_module_name()
     |> Enum.join(".")
     # Append action
     |> String.replace_suffix("", "##{action_name}")
@@ -122,7 +121,7 @@ defmodule ScoutApm.Plugs.ControllerTimer do
     Integer.parse(queue_start_ms)
   end
 
-  defp num_parts_to_drop do
-    if Config.find(:trim_app_module_name), do: 1, else: 0
+  defp trim_app_module_name(parts) do
+    if Config.find(:trim_app_module_name), do: Enum.drop(parts, 1), else: parts
   end
 end

--- a/lib/scout_apm/plugs/controller_timer.ex
+++ b/lib/scout_apm/plugs/controller_timer.ex
@@ -1,6 +1,6 @@
 defmodule ScoutApm.Plugs.ControllerTimer do
   alias ScoutApm.Internal.Layer
-  alias ScoutApm.{Context, TrackedRequest, Config}
+  alias ScoutApm.{Context, TrackedRequest}
   @queue_headers ~w(x-queue-start x-request-start)
 
   def init(default), do: default

--- a/lib/scout_apm/plugs/controller_timer.ex
+++ b/lib/scout_apm/plugs/controller_timer.ex
@@ -70,7 +70,7 @@ defmodule ScoutApm.Plugs.ControllerTimer do
     |> trim_app_module_name(include_app_name)
     |> Enum.join(".")
     # Append action
-    |> String.replace_suffix("", "##{action_name}")
+    |> Kernel.<>("##{action_name}")
   end
 
   defp add_ip_context(conn) do

--- a/test/scout_apm/plugs/controller_timer_test.exs
+++ b/test/scout_apm/plugs/controller_timer_test.exs
@@ -1,6 +1,7 @@
 defmodule ScoutApm.Plugs.ControllerTimerTest do
   use ExUnit.Case
   use Plug.Test
+  alias ScoutApm.Plugs.ControllerTimer
 
   setup do
     ScoutApm.TestCollector.clear_messages()
@@ -137,5 +138,25 @@ defmodule ScoutApm.Plugs.ControllerTimerTest do
     queue_time = String.to_integer(queue_time)
     assert queue_time >= 10_000_000
     assert queue_time < 100_000_000
+  end
+
+  describe "action_name/1" do
+    setup do
+      conn = conn(:get, "/") |> ScoutApm.TestPlugApp.call([])
+
+      [conn: conn]
+    end
+
+    test "configured to trim app module name (default)", %{conn: conn} do
+      assert ControllerTimer.action_name(conn) == "PageController#index"
+    end
+
+    test "configured to not trim app module name", %{conn: conn} do
+      Application.put_env(:scout_apm, :trim_app_module_name, false)
+
+      assert ControllerTimer.action_name(conn) == "MyTestApp.PageController#index"
+
+      Application.put_env(:scout_apm, :trim_app_module_name, true)
+    end
   end
 end

--- a/test/scout_apm/plugs/controller_timer_test.exs
+++ b/test/scout_apm/plugs/controller_timer_test.exs
@@ -147,11 +147,11 @@ defmodule ScoutApm.Plugs.ControllerTimerTest do
       [conn: conn]
     end
 
-    test "configured to trim app module name (default)", %{conn: conn} do
+    test "configured to trim application name (default)", %{conn: conn} do
       assert ControllerTimer.action_name(conn, []) == "PageController#index"
     end
 
-    test "configured to not trim app module name", %{conn: conn} do
+    test "configured to include application name", %{conn: conn} do
       assert ControllerTimer.action_name(conn, include_application_name: true) ==
                "MyTestApp.PageController#index"
     end

--- a/test/scout_apm/plugs/controller_timer_test.exs
+++ b/test/scout_apm/plugs/controller_timer_test.exs
@@ -148,15 +148,12 @@ defmodule ScoutApm.Plugs.ControllerTimerTest do
     end
 
     test "configured to trim app module name (default)", %{conn: conn} do
-      assert ControllerTimer.action_name(conn) == "PageController#index"
+      assert ControllerTimer.action_name(conn, []) == "PageController#index"
     end
 
     test "configured to not trim app module name", %{conn: conn} do
-      Application.put_env(:scout_apm, :trim_app_module_name, false)
-
-      assert ControllerTimer.action_name(conn) == "MyTestApp.PageController#index"
-
-      Application.put_env(:scout_apm, :trim_app_module_name, true)
+      assert ControllerTimer.action_name(conn, include_application_name: true) ==
+               "MyTestApp.PageController#index"
     end
   end
 end


### PR DESCRIPTION
Currently, the way the library is setup controller instrumentation
reports controller names sans the app name. As an example, in a standard
Phoenix app if I have a controller called `ExampleApp.SessionController`
then it will be reported under `SessionController#action_name`. This is
very convenient for apps that only have one phoenix app since it reduces
verbosity.

However, we're running Scout in an umbrella app that has multiple
Phoenix apps underneath it. So in our setup we might have something that
looks like this: `ExampleApp1.SessionController` and
`ExampleApp2.SessionController`. With the current implementation,
instrumentation of both controllers results in metrics being sent to the
same `SessionController#action_name` which is undesirable because we
would like them to be reported separately under their respective app
names.

In order to retain the existing behavior and avoid introducing a change
that would cause issues with anyone's existing metrics I've introduced a
configuration option that controls whether or not the app module name is
trimmed. By default the value is `true` indicating that the app module
name will be trimmed.