### PR TITLE
Prevent AgentManager OOM 

### DIFF
--- a/lib/scout_apm/core/agent_manager.ex
+++ b/lib/scout_apm/core/agent_manager.ex
@@ -18,12 +18,20 @@ defmodule ScoutApm.Core.AgentManager do
   @impl GenServer
   @spec init(any) :: {:ok, t()}
   def init(_) do
+    handle_max_heap()
     start_setup()
     {:ok, %__MODULE__{socket: nil}}
   end
 
   def start_setup do
     GenServer.cast(__MODULE__, :setup)
+  end
+
+  defp handle_max_heap do
+    case ScoutApm.Config.find(:max_heap_size) do
+      nil -> nil
+      val -> Process.flag(:max_heap_size, val)
+    end
   end
 
   @spec setup :: :gen_tcp.socket() | nil


### PR DESCRIPTION
Hi,

We have had an issue for the past few months that agent_manager receives messages faster than it can handle. These messages end up taking more and more memory and eventually BEAM crashes due to out of memory. 

This PR allows us to set `max_heap_size`, when the heap surpasses this limit the process will be killed (and then restarted by the supervisor).  