### PR TITLE
Add missing param in start_link definition

### DIFF
--- a/lib/scout_apm/commands.ex
+++ b/lib/scout_apm/commands.ex
@@ -164,7 +164,7 @@ defmodule ScoutApm.Command.ApplicationEvent do
   end
 end
 
-defimpl ScoutApm.Command, for: ScoutApm.Command  do
+defimpl ScoutApm.Command, for: ScoutApm.Command.ApplicationEvent  do
   def message(%Command.ApplicationEvent{} = event) do
     %{
       ApplicationEvent: %{

--- a/lib/scout_apm/core/agent_manager.ex
+++ b/lib/scout_apm/core/agent_manager.ex
@@ -10,7 +10,7 @@ defmodule ScoutApm.Core.AgentManager do
           socket: :gen_tcp.socket() | nil
         }
 
-  def start_link() do
+  def start_link(_) do
     options = []
     GenServer.start_link(__MODULE__, options, name: __MODULE__)
   end


### PR DESCRIPTION
- Use the correct function signature for `start_link` in `ScoutApm.Core.AgentManager`.
- Fix typo in `commands.ex`.