### PR TITLE
Add error monitoring capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,68 @@ config :phoenix, :template_engines,
   heex: ScoutApm.Instruments.HEExEngine  # Only if phoenix_live_view is installed
 ```
 
+## Error Tracking
+
+Scout APM captures errors automatically and allows manual error capture.
+
+### Automatic Error Capture
+
+Errors are automatically captured from:
+- Phoenix controller exceptions (via telemetry)
+- LiveView exceptions (mount, handle_event, handle_params)
+- Oban job failures
+- Code wrapped in `transaction` blocks
+
+To enable Phoenix router-level error capture, add to your application startup:
+
+```elixir
+# In your application.ex start/2
+def start(_type, _args) do
+  ScoutApm.Instruments.PhoenixErrorTelemetry.attach()
+  # ... rest of supervision tree
+end
+```
+
+### Manual Error Capture
+
+Capture errors manually with `ScoutApm.Error.capture/2`:
+
+```elixir
+try do
+  risky_operation()
+rescue
+  e ->
+    ScoutApm.Error.capture(e, stacktrace: __STACKTRACE__)
+    reraise e, __STACKTRACE__
+end
+```
+
+With additional context:
+
+```elixir
+ScoutApm.Error.capture(exception,
+  stacktrace: __STACKTRACE__,
+  context: %{user_id: user.id},
+  request_path: conn.request_path,
+  request_params: conn.params
+)
+```
+
+### Configuration
+
+```elixir
+config :scout_apm,
+  # Enable/disable error capture (default: true)
+  errors_enabled: true,
+
+  # Exceptions to ignore (default: [])
+  errors_ignored_exceptions: [Phoenix.Router.NoRouteError],
+
+  # Additional parameter keys to filter (default: [])
+  # Built-in: password, token, secret, api_key, auth, credentials, etc.
+  errors_filter_parameters: ["credit_card", "cvv"]
+```
+
 ## Development
 
 See [TESTING.md](TESTING.md) for information on testing with different template engine configurations.

--- a/lib/scout_apm/application.ex
+++ b/lib/scout_apm/application.ex
@@ -17,7 +17,9 @@ defmodule ScoutApm.Application do
     :core_agent_tcp_port,
     :core_agent_log_level,
     :core_agent_log_file,
-    :core_agent_config_file
+    :core_agent_config_file,
+    :errors_enabled,
+    :errors_host
   ]
 
   def start(_type, _args) do
@@ -28,7 +30,8 @@ defmodule ScoutApm.Application do
       Supervisor.child_spec({ScoutApm.Watcher, ScoutApm.PersistentHistogram},
         id: :histogram_watcher
       ),
-      collector_module
+      collector_module,
+      ScoutApm.Error.ErrorService
     ]
 
     ScoutApm.Cache.setup()

--- a/lib/scout_apm/config.ex
+++ b/lib/scout_apm/config.ex
@@ -40,6 +40,7 @@ defmodule ScoutApm.Config do
   defp coercion(:core_agent_launch), do: &Coercions.boolean/1
   defp coercion(:core_agent_download), do: &Coercions.boolean/1
   defp coercion(:dev_trace), do: &Coercions.boolean/1
+  defp coercion(:errors_enabled), do: &Coercions.boolean/1
   defp coercion(:log_level), do: &Coercions.log_level/1
   defp coercion(:ignore), do: &Coercions.json/1
   defp coercion(_), do: fn x -> {:ok, x} end

--- a/lib/scout_apm/config/defaults.ex
+++ b/lib/scout_apm/config/defaults.ex
@@ -15,7 +15,15 @@ defmodule ScoutApm.Config.Defaults do
       core_agent_tcp_port: 9000,
       collector_module: ScoutApm.Core.AgentManager,
       download_url:
-        "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release"
+        "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release",
+      # Error tracking configuration
+      errors_enabled: true,
+      errors_host: "https://errors.scoutapm.com",
+      errors_batch_size: 5,
+      errors_max_queue_size: 500,
+      errors_flush_interval_ms: 1_000,
+      errors_ignored_exceptions: [],
+      errors_filter_parameters: []
     }
   end
 

--- a/lib/scout_apm/error.ex
+++ b/lib/scout_apm/error.ex
@@ -1,0 +1,165 @@
+defmodule ScoutApm.Error do
+  @moduledoc """
+  Public API for capturing errors in Scout APM.
+
+  Errors can be captured manually using `capture/1` or `capture/2`, or
+  automatically via Phoenix telemetry handlers.
+
+  ## Manual Error Capture
+
+      try do
+        some_risky_operation()
+      rescue
+        e ->
+          ScoutApm.Error.capture(e, stacktrace: __STACKTRACE__)
+          reraise e, __STACKTRACE__
+      end
+
+  ## With Additional Context
+
+      try do
+        process_user_request(user)
+      rescue
+        e ->
+          ScoutApm.Error.capture(e,
+            stacktrace: __STACKTRACE__,
+            context: %{user_id: user.id},
+            request_path: "/api/users",
+            request_params: %{action: "update"}
+          )
+          reraise e, __STACKTRACE__
+      end
+
+  ## Configuration
+
+  Error capture can be configured in your config:
+
+      config :scout_apm,
+        errors_enabled: true,
+        errors_ignored_exceptions: [Phoenix.Router.NoRouteError],
+        errors_filter_parameters: ["credit_card", "cvv"]
+
+  ## Options
+
+  All capture functions accept these options:
+
+    * `:stacktrace` - The exception stacktrace. For best results, pass `__STACKTRACE__`
+      from within a rescue block.
+    * `:context` - A map of additional context to include with the error.
+    * `:request_path` - The request path (e.g., "/api/users").
+    * `:request_params` - A map of request parameters.
+    * `:session` - A map of session data.
+    * `:custom_controller` - Override the controller name.
+    * `:custom_params` - A map of custom parameters.
+  """
+
+  alias ScoutApm.Error.ErrorData
+  alias ScoutApm.Error.ErrorService
+
+  @type capture_opts :: [
+          stacktrace: Exception.stacktrace(),
+          context: map(),
+          request_path: String.t(),
+          request_params: map(),
+          session: map(),
+          custom_controller: String.t(),
+          custom_params: map()
+        ]
+
+  @doc """
+  Captures an exception and sends it to Scout APM.
+
+  The stacktrace will be captured automatically if not provided, but for
+  best results, pass `__STACKTRACE__` from within a rescue block.
+
+  Returns `:ok` on success.
+
+  ## Examples
+
+      try do
+        do_something_risky()
+      rescue
+        e ->
+          ScoutApm.Error.capture(e, stacktrace: __STACKTRACE__)
+          reraise e, __STACKTRACE__
+      end
+
+      # With additional context
+      ScoutApm.Error.capture(exception,
+        stacktrace: __STACKTRACE__,
+        context: %{user_id: 123},
+        request_path: conn.request_path
+      )
+  """
+  @spec capture(Exception.t(), capture_opts()) :: :ok
+  def capture(exception, opts \\ []) when is_exception(exception) do
+    if errors_enabled?() and not ignored_exception?(exception) do
+      error_data = ErrorData.from_exception(exception, opts)
+      ErrorService.send(error_data)
+    end
+
+    :ok
+  end
+
+  @doc """
+  Captures an error from kind/reason/stacktrace tuple (as received in
+  telemetry exception events).
+
+  This is primarily used internally by telemetry handlers but can be called
+  directly when handling exceptions in catch blocks.
+
+  ## Examples
+
+      try do
+        do_something()
+      catch
+        kind, reason ->
+          ScoutApm.Error.capture_from_telemetry(kind, reason, __STACKTRACE__)
+          :erlang.raise(kind, reason, __STACKTRACE__)
+      end
+  """
+  @spec capture_from_telemetry(
+          kind :: :error | :throw | :exit,
+          reason :: term(),
+          stacktrace :: Exception.stacktrace(),
+          capture_opts()
+        ) :: :ok
+  def capture_from_telemetry(kind, reason, stacktrace, opts \\ []) do
+    if errors_enabled?() do
+      error_data = ErrorData.from_telemetry(kind, reason, stacktrace, opts)
+
+      if error_data && not ignored_exception_class?(error_data.exception_class) do
+        ErrorService.send(error_data)
+      end
+    end
+
+    :ok
+  end
+
+  @doc """
+  Returns whether error capture is currently enabled.
+  """
+  @spec enabled?() :: boolean()
+  def enabled? do
+    errors_enabled?()
+  end
+
+  defp errors_enabled? do
+    ScoutApm.Config.find(:errors_enabled) != false and
+      ScoutApm.Config.find(:monitor) == true
+  end
+
+  defp ignored_exception?(exception) do
+    ignored = ScoutApm.Config.find(:errors_ignored_exceptions) || []
+    Enum.any?(ignored, fn mod -> is_struct(exception, mod) end)
+  end
+
+  defp ignored_exception_class?(class_name) do
+    ignored = ScoutApm.Config.find(:errors_ignored_exceptions) || []
+
+    Enum.any?(ignored, fn mod ->
+      mod_name = Module.split(mod) |> List.last()
+      mod_name == class_name
+    end)
+  end
+end

--- a/lib/scout_apm/error/error_data.ex
+++ b/lib/scout_apm/error/error_data.ex
@@ -1,0 +1,264 @@
+defmodule ScoutApm.Error.ErrorData do
+  @moduledoc """
+  Internal representation of an error to be sent to Scout APM.
+  Matches the Python agent's error data structure for backend compatibility.
+  """
+
+  alias ScoutApm.Error.ParameterFilter
+
+  defstruct [
+    :exception_class,
+    :message,
+    :request_id,
+    :request_uri,
+    :request_params,
+    :request_session,
+    :environment,
+    :trace,
+    :request_components,
+    :context,
+    :host,
+    :revision_sha
+  ]
+
+  @type t :: %__MODULE__{
+          exception_class: String.t(),
+          message: String.t(),
+          request_id: String.t() | nil,
+          request_uri: String.t() | nil,
+          request_params: map() | nil,
+          request_session: map() | nil,
+          environment: map() | nil,
+          trace: [String.t()],
+          request_components: map() | nil,
+          context: map(),
+          host: String.t() | nil,
+          revision_sha: String.t() | nil
+        }
+
+  @doc """
+  Creates an ErrorData struct from an Elixir exception.
+  """
+  @spec from_exception(Exception.t(), keyword()) :: t()
+  def from_exception(exception, opts \\ []) do
+    stacktrace = Keyword.get(opts, :stacktrace) || get_current_stacktrace()
+
+    %__MODULE__{
+      exception_class: exception_class_name(exception),
+      message: Exception.message(exception),
+      request_id: get_request_id(),
+      request_uri: Keyword.get(opts, :request_path),
+      request_params: opts |> Keyword.get(:request_params) |> ParameterFilter.filter(),
+      request_session: opts |> Keyword.get(:session) |> ParameterFilter.filter(),
+      environment: opts |> Keyword.get(:environment) |> ParameterFilter.filter(),
+      trace: format_stacktrace(stacktrace),
+      request_components: build_request_components(opts),
+      context: build_context(opts),
+      host: ScoutApm.Cache.hostname(),
+      revision_sha: ScoutApm.Cache.git_sha()
+    }
+  end
+
+  @doc """
+  Creates an ErrorData struct from telemetry exception data.
+  """
+  @spec from_telemetry(:error | :throw | :exit, term(), Exception.stacktrace(), keyword()) ::
+          t() | nil
+  def from_telemetry(:error, reason, stacktrace, opts) when is_exception(reason) do
+    from_exception(reason, Keyword.put(opts, :stacktrace, stacktrace))
+  end
+
+  def from_telemetry(:error, reason, stacktrace, opts) do
+    %__MODULE__{
+      exception_class: "ErlangError",
+      message: inspect(reason, limit: 500),
+      request_id: get_request_id(),
+      request_uri: Keyword.get(opts, :request_path),
+      request_params: opts |> Keyword.get(:request_params) |> ParameterFilter.filter(),
+      request_session: opts |> Keyword.get(:session) |> ParameterFilter.filter(),
+      environment: nil,
+      trace: format_stacktrace(stacktrace),
+      request_components: build_request_components(opts),
+      context: build_context(opts),
+      host: ScoutApm.Cache.hostname(),
+      revision_sha: ScoutApm.Cache.git_sha()
+    }
+  end
+
+  def from_telemetry(:throw, reason, stacktrace, opts) do
+    %__MODULE__{
+      exception_class: "ThrowError",
+      message: inspect(reason, limit: 500),
+      request_id: get_request_id(),
+      request_uri: Keyword.get(opts, :request_path),
+      request_params: opts |> Keyword.get(:request_params) |> ParameterFilter.filter(),
+      request_session: opts |> Keyword.get(:session) |> ParameterFilter.filter(),
+      environment: nil,
+      trace: format_stacktrace(stacktrace),
+      request_components: build_request_components(opts),
+      context: build_context(opts),
+      host: ScoutApm.Cache.hostname(),
+      revision_sha: ScoutApm.Cache.git_sha()
+    }
+  end
+
+  def from_telemetry(:exit, reason, stacktrace, opts) do
+    %__MODULE__{
+      exception_class: "ExitError",
+      message: inspect(reason, limit: 500),
+      request_id: get_request_id(),
+      request_uri: Keyword.get(opts, :request_path),
+      request_params: opts |> Keyword.get(:request_params) |> ParameterFilter.filter(),
+      request_session: opts |> Keyword.get(:session) |> ParameterFilter.filter(),
+      environment: nil,
+      trace: format_stacktrace(stacktrace),
+      request_components: build_request_components(opts),
+      context: build_context(opts),
+      host: ScoutApm.Cache.hostname(),
+      revision_sha: ScoutApm.Cache.git_sha()
+    }
+  end
+
+  @doc """
+  Converts the ErrorData to a map suitable for JSON encoding.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = error) do
+    %{
+      "exception_class" => error.exception_class,
+      "message" => error.message,
+      "request_id" => error.request_id,
+      "request_uri" => error.request_uri,
+      "request_params" => error.request_params,
+      "request_session" => error.request_session,
+      "environment" => error.environment,
+      "trace" => error.trace,
+      "request_components" => error.request_components,
+      "context" => error.context,
+      "host" => error.host,
+      "revision_sha" => error.revision_sha
+    }
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Map.new()
+  end
+
+  # Private helpers
+
+  defp exception_class_name(exception) do
+    exception.__struct__
+    |> Module.split()
+    |> List.last()
+  end
+
+  defp get_request_id do
+    case Process.get(:scout_apm_request) do
+      %{id: id} -> id
+      _ -> ScoutApm.Utils.random_string(12)
+    end
+  end
+
+  defp get_current_stacktrace do
+    {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)
+    # Drop the first few frames that are internal to this module
+    Enum.drop(stacktrace, 4)
+  end
+
+  defp format_stacktrace(stacktrace) do
+    scm_subdirectory = ScoutApm.Config.find(:scm_subdirectory) || ""
+
+    stacktrace
+    # Limit to 50 frames like Python
+    |> Enum.take(50)
+    |> Enum.map(fn
+      {mod, fun, arity, location} when is_integer(arity) ->
+        file = Keyword.get(location, :file, ~c"nofile") |> to_string()
+        line = Keyword.get(location, :line, 0)
+
+        file_path =
+          if scm_subdirectory != "", do: Path.join(scm_subdirectory, file), else: file
+
+        "#{file_path}:#{line}:in #{inspect(mod)}.#{fun}/#{arity}"
+
+      {mod, fun, args, location} when is_list(args) ->
+        file = Keyword.get(location, :file, ~c"nofile") |> to_string()
+        line = Keyword.get(location, :line, 0)
+        arity = length(args)
+
+        file_path =
+          if scm_subdirectory != "", do: Path.join(scm_subdirectory, file), else: file
+
+        "#{file_path}:#{line}:in #{inspect(mod)}.#{fun}/#{arity}"
+
+      frame ->
+        Exception.format_stacktrace_entry(frame)
+    end)
+  end
+
+  defp build_request_components(opts) do
+    custom_controller = Keyword.get(opts, :custom_controller)
+
+    # Try to get from tracked request
+    tracked_request = Process.get(:scout_apm_request)
+
+    cond do
+      custom_controller ->
+        %{"module" => nil, "controller" => custom_controller, "action" => nil}
+
+      tracked_request && tracked_request.root_layer ->
+        parse_controller_action(tracked_request.root_layer.name)
+
+      tracked_request && length(tracked_request.layers) > 0 ->
+        # Get the bottom-most layer (first in list since it's a stack)
+        layer = List.last(tracked_request.layers)
+        parse_controller_action(layer.name)
+
+      true ->
+        nil
+    end
+  end
+
+  defp parse_controller_action(nil), do: nil
+
+  defp parse_controller_action(name) do
+    case String.split(name, "#", parts: 2) do
+      [controller, action] ->
+        %{"module" => nil, "controller" => controller, "action" => action}
+
+      [controller] ->
+        %{"module" => nil, "controller" => controller, "action" => nil}
+    end
+  end
+
+  defp build_context(opts) do
+    custom_params = Keyword.get(opts, :custom_params, %{})
+    user_context = Keyword.get(opts, :context, %{})
+
+    # Get context from tracked request
+    tracked_request = Process.get(:scout_apm_request)
+
+    request_context =
+      if tracked_request do
+        contexts_map =
+          tracked_request.contexts
+          |> Enum.map(fn %{key: k, value: v} -> {k, v} end)
+          |> Map.new()
+
+        Map.put(contexts_map, "transaction_id", tracked_request.id)
+      else
+        %{}
+      end
+
+    base_context =
+      request_context
+      |> Map.merge(user_context)
+
+    # Only add custom_params if not empty
+    if map_size(custom_params) > 0 do
+      Map.put(base_context, "custom_params", custom_params)
+    else
+      base_context
+    end
+    |> Enum.reject(fn {_k, v} -> v == %{} or is_nil(v) end)
+    |> Map.new()
+  end
+end

--- a/lib/scout_apm/error/error_service.ex
+++ b/lib/scout_apm/error/error_service.ex
@@ -1,0 +1,271 @@
+defmodule ScoutApm.Error.ErrorService do
+  @moduledoc """
+  Background GenServer that batches and sends errors to Scout APM's error endpoint.
+
+  Implements a queue with batching (default 5 errors per batch) and a maximum
+  queue size (default 500) to prevent memory issues.
+  """
+
+  use GenServer
+
+  alias ScoutApm.Error.ErrorData
+
+  @default_batch_size 5
+  @default_max_queue_size 500
+  @default_flush_interval_ms 1_000
+  @errors_endpoint "/apps/error.scout"
+
+  defstruct [
+    :queue,
+    :queue_size,
+    :timer_ref
+  ]
+
+  @type t :: %__MODULE__{
+          queue: :queue.queue(ErrorData.t()),
+          queue_size: non_neg_integer(),
+          timer_ref: reference() | nil
+        }
+
+  # Client API
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Sends an error to the service for batched delivery.
+  Non-blocking - returns immediately.
+  """
+  @spec send(ErrorData.t()) :: :ok
+  def send(%ErrorData{} = error) do
+    GenServer.cast(__MODULE__, {:send, error})
+  end
+
+  @doc """
+  Waits for the queue to drain. Used in tests and shutdown.
+  """
+  @spec drain(timeout :: non_neg_integer()) :: :ok | :timeout
+  def drain(timeout \\ 5_000) do
+    GenServer.call(__MODULE__, :drain, timeout)
+  catch
+    :exit, _ -> :timeout
+  end
+
+  @doc """
+  Forces an immediate flush of queued errors. Used in tests.
+  """
+  @spec flush() :: :ok
+  def flush do
+    GenServer.call(__MODULE__, :flush)
+  end
+
+  # Server Callbacks
+
+  @impl GenServer
+  def init(_opts) do
+    state = %__MODULE__{
+      queue: :queue.new(),
+      queue_size: 0,
+      timer_ref: nil
+    }
+
+    {:ok, schedule_flush(state)}
+  end
+
+  @impl GenServer
+  def handle_cast({:send, %ErrorData{} = error}, state) do
+    max_size = get_max_queue_size()
+
+    if state.queue_size >= max_size do
+      ScoutApm.Logger.log(:debug, "Error queue full (#{max_size}), dropping error")
+      {:noreply, state}
+    else
+      new_queue = :queue.in(error, state.queue)
+      new_state = %{state | queue: new_queue, queue_size: state.queue_size + 1}
+
+      # If we've hit batch size, flush immediately
+      if new_state.queue_size >= get_batch_size() do
+        {:noreply, do_flush(new_state)}
+      else
+        {:noreply, new_state}
+      end
+    end
+  end
+
+  @impl GenServer
+  def handle_call(:drain, _from, state) do
+    new_state = drain_all(state)
+    {:reply, :ok, new_state}
+  end
+
+  @impl GenServer
+  def handle_call(:flush, _from, state) do
+    new_state = do_flush(state)
+    {:reply, :ok, new_state}
+  end
+
+  @impl GenServer
+  def handle_info(:flush, state) do
+    new_state =
+      state
+      |> do_flush()
+      |> schedule_flush()
+
+    {:noreply, new_state}
+  end
+
+  @impl GenServer
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    drain_all(state)
+    :ok
+  end
+
+  # Private Functions
+
+  defp schedule_flush(state) do
+    if state.timer_ref, do: Process.cancel_timer(state.timer_ref)
+
+    timer_ref = Process.send_after(self(), :flush, get_flush_interval())
+    %{state | timer_ref: timer_ref}
+  end
+
+  defp do_flush(%{queue_size: 0} = state), do: state
+
+  defp do_flush(state) do
+    batch_size = get_batch_size()
+
+    {errors, remaining_queue, remaining_size} =
+      dequeue_batch(state.queue, state.queue_size, batch_size)
+
+    if length(errors) > 0 do
+      Task.start(fn -> send_errors(errors) end)
+    end
+
+    %{state | queue: remaining_queue, queue_size: remaining_size}
+  end
+
+  defp drain_all(%{queue_size: 0} = state), do: state
+
+  defp drain_all(state) do
+    {errors, remaining_queue, remaining_size} =
+      dequeue_batch(state.queue, state.queue_size, state.queue_size)
+
+    if length(errors) > 0 do
+      # Send synchronously during drain
+      send_errors(errors)
+    end
+
+    %{state | queue: remaining_queue, queue_size: remaining_size}
+  end
+
+  defp dequeue_batch(queue, queue_size, batch_size) do
+    count = min(batch_size, queue_size)
+
+    {errors, new_queue} =
+      Enum.reduce(1..max(count, 1), {[], queue}, fn
+        _, {acc, q} when length(acc) >= count ->
+          {acc, q}
+
+        _, {acc, q} ->
+          case :queue.out(q) do
+            {{:value, error}, new_q} -> {[error | acc], new_q}
+            {:empty, q} -> {acc, q}
+          end
+      end)
+
+    {Enum.reverse(errors), new_queue, queue_size - length(errors)}
+  end
+
+  defp send_errors([]), do: :ok
+
+  defp send_errors(errors) do
+    payload = build_payload(errors)
+
+    case Jason.encode(payload) do
+      {:ok, json} ->
+        compressed = :zlib.gzip(json)
+        do_http_send(compressed, length(errors))
+
+      {:error, reason} ->
+        ScoutApm.Logger.log(:debug, "Failed to encode error payload: #{inspect(reason)}")
+    end
+  end
+
+  defp build_payload(errors) do
+    %{
+      "notifier" => "scout_apm_elixir",
+      "environment" => get_environment(),
+      "root" => ScoutApm.Config.find(:application_root) || File.cwd!(),
+      "problems" => Enum.map(errors, &ErrorData.to_map/1)
+    }
+  end
+
+  defp get_environment do
+    case ScoutApm.Config.find(:environment) do
+      nil ->
+        if function_exported?(Mix, :env, 0) do
+          Mix.env() |> to_string()
+        else
+          "production"
+        end
+
+      env ->
+        to_string(env)
+    end
+  end
+
+  defp do_http_send(body, error_count) do
+    url = build_url()
+    headers = build_headers(error_count)
+
+    case :hackney.request(:post, url, headers, body, [:with_body]) do
+      {:ok, status, _headers, _body} when status < 400 ->
+        ScoutApm.Logger.log(:debug, "Successfully sent #{error_count} errors to Scout APM")
+        :ok
+
+      {:ok, status, _headers, response_body} ->
+        ScoutApm.Logger.log(
+          :debug,
+          "Error sending to Scout APM errors endpoint. Status: #{status}, Body: #{inspect(response_body)}"
+        )
+
+        {:error, {:http_error, status}}
+
+      {:error, reason} ->
+        ScoutApm.Logger.log(:debug, "Error sending to Scout APM: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  defp build_url do
+    host = ScoutApm.Config.find(:errors_host) || "https://errors.scoutapm.com"
+    key = ScoutApm.Config.find(:key) || ""
+    name = ScoutApm.Config.find(:name) || ""
+
+    query = URI.encode_query(%{"key" => key, "name" => name})
+    "#{host}#{@errors_endpoint}?#{query}"
+  end
+
+  defp build_headers(error_count) do
+    [
+      {"Agent-Hostname", ScoutApm.Cache.hostname() || ""},
+      {"Content-Encoding", "gzip"},
+      {"Content-Type", "application/json"},
+      {"X-Error-Count", to_string(error_count)}
+    ]
+  end
+
+  defp get_batch_size, do: ScoutApm.Config.find(:errors_batch_size) || @default_batch_size
+
+  defp get_max_queue_size,
+    do: ScoutApm.Config.find(:errors_max_queue_size) || @default_max_queue_size
+
+  defp get_flush_interval,
+    do: ScoutApm.Config.find(:errors_flush_interval_ms) || @default_flush_interval_ms
+end

--- a/lib/scout_apm/error/parameter_filter.ex
+++ b/lib/scout_apm/error/parameter_filter.ex
@@ -1,0 +1,83 @@
+defmodule ScoutApm.Error.ParameterFilter do
+  @moduledoc """
+  Filters sensitive parameters from request data before sending to Scout APM.
+  Matches the Python agent's FILTER_PARAMETERS list.
+  """
+
+  @default_filter_parameters MapSet.new([
+                               "access",
+                               "access_token",
+                               "api_key",
+                               "apikey",
+                               "auth",
+                               "auth_token",
+                               "card[number]",
+                               "certificate",
+                               "credentials",
+                               "crypt",
+                               "key",
+                               "mysql_pwd",
+                               "otp",
+                               "passwd",
+                               "password",
+                               "private",
+                               "protected",
+                               "salt",
+                               "secret",
+                               "secret_key",
+                               "ssn",
+                               "stripetoken",
+                               "token"
+                             ])
+
+  @filtered_value "[FILTERED]"
+
+  @doc """
+  Filters sensitive parameters from a map or nil value.
+  """
+  @spec filter(map() | list() | nil) :: map() | list() | nil
+  def filter(nil), do: nil
+  def filter(params) when is_map(params), do: filter_map(params)
+  def filter(params) when is_list(params), do: Enum.map(params, &filter_value/1)
+  def filter(value), do: value
+
+  defp filter_map(map) do
+    filter_params = get_filter_parameters()
+
+    map
+    |> Enum.map(fn {key, value} ->
+      key_str = to_string(key) |> String.downcase()
+
+      if MapSet.member?(filter_params, key_str) do
+        {key, @filtered_value}
+      else
+        {key, filter_value(value)}
+      end
+    end)
+    |> Map.new()
+  end
+
+  defp filter_value(value) when is_map(value), do: filter_map(value)
+  defp filter_value(value) when is_list(value), do: Enum.map(value, &filter_value/1)
+  defp filter_value(nil), do: nil
+
+  defp filter_value(value) do
+    case value do
+      v when is_binary(v) -> v
+      v when is_number(v) -> v
+      v when is_boolean(v) -> v
+      v when is_atom(v) -> Atom.to_string(v)
+      v -> inspect(v, limit: 100)
+    end
+  end
+
+  defp get_filter_parameters do
+    custom = ScoutApm.Config.find(:errors_filter_parameters) || []
+
+    custom
+    |> Enum.map(&to_string/1)
+    |> Enum.map(&String.downcase/1)
+    |> MapSet.new()
+    |> MapSet.union(@default_filter_parameters)
+  end
+end

--- a/lib/scout_apm/instruments/live_view_telemetry.ex
+++ b/lib/scout_apm/instruments/live_view_telemetry.ex
@@ -141,13 +141,19 @@ if Code.ensure_loaded?(Telemetry) || Code.ensure_loaded?(:telemetry) do
     def handle_event(
           [:phoenix, :live_view, :mount, :exception],
           _measurements,
-          %{socket: socket} = _metadata,
+          %{socket: socket, kind: kind, reason: reason, stacktrace: stacktrace} = _metadata,
           _config
         ) do
       view_module = socket.view
       name = live_view_name(view_module, "mount")
 
       TrackedRequest.mark_error()
+
+      # Capture full error details
+      ScoutApm.Error.capture_from_telemetry(kind, reason, stacktrace,
+        request_path: get_uri_from_socket(socket),
+        custom_controller: name
+      )
 
       TrackedRequest.stop_layer(fn layer ->
         layer
@@ -199,13 +205,20 @@ if Code.ensure_loaded?(Telemetry) || Code.ensure_loaded?(:telemetry) do
     def handle_event(
           [:phoenix, :live_view, :handle_event, :exception],
           _measurements,
-          %{socket: socket, event: event} = _metadata,
+          %{socket: socket, event: event, kind: kind, reason: reason, stacktrace: stacktrace} =
+            _metadata,
           _config
         ) do
       view_module = socket.view
       name = live_view_name(view_module, "handle_event:#{event}")
 
       TrackedRequest.mark_error()
+
+      # Capture full error details
+      ScoutApm.Error.capture_from_telemetry(kind, reason, stacktrace,
+        request_path: get_uri_from_socket(socket),
+        custom_controller: name
+      )
 
       TrackedRequest.stop_layer(fn layer ->
         layer
@@ -248,13 +261,19 @@ if Code.ensure_loaded?(Telemetry) || Code.ensure_loaded?(:telemetry) do
     def handle_event(
           [:phoenix, :live_view, :handle_params, :exception],
           _measurements,
-          %{socket: socket} = _metadata,
+          %{socket: socket, kind: kind, reason: reason, stacktrace: stacktrace} = _metadata,
           _config
         ) do
       view_module = socket.view
       name = live_view_name(view_module, "handle_params")
 
       TrackedRequest.mark_error()
+
+      # Capture full error details
+      ScoutApm.Error.capture_from_telemetry(kind, reason, stacktrace,
+        request_path: get_uri_from_socket(socket),
+        custom_controller: name
+      )
 
       TrackedRequest.stop_layer(fn layer ->
         layer

--- a/lib/scout_apm/instruments/oban_telemetry.ex
+++ b/lib/scout_apm/instruments/oban_telemetry.ex
@@ -95,12 +95,18 @@ if Code.ensure_loaded?(Telemetry) || Code.ensure_loaded?(:telemetry) do
     def handle_event(
           [:oban, :job, :exception],
           _measurements,
-          %{job: job, kind: kind, reason: reason} = _metadata,
+          %{job: job, kind: kind, reason: reason, stacktrace: stacktrace} = _metadata,
           _config
         ) do
       name = job_name(job)
 
       TrackedRequest.mark_error()
+
+      # Capture full error details
+      ScoutApm.Error.capture_from_telemetry(kind, reason, stacktrace,
+        custom_controller: name,
+        custom_params: %{queue: job.queue, worker: job.worker}
+      )
 
       TrackedRequest.stop_layer(fn layer ->
         layer

--- a/lib/scout_apm/instruments/phoenix_error_telemetry.ex
+++ b/lib/scout_apm/instruments/phoenix_error_telemetry.ex
@@ -1,0 +1,141 @@
+if Code.ensure_loaded?(Telemetry) || Code.ensure_loaded?(:telemetry) do
+  defmodule ScoutApm.Instruments.PhoenixErrorTelemetry do
+    @moduledoc """
+    Telemetry handler for automatic Phoenix error capture.
+
+    Attaches to Phoenix telemetry events to automatically capture:
+    - Router dispatch exceptions
+    - Error rendering events
+
+    ## Usage
+
+    In your application's `start/2` function:
+
+        def start(_type, _args) do
+          ScoutApm.Instruments.PhoenixErrorTelemetry.attach()
+          # ... rest of supervision tree
+        end
+
+    This will automatically capture all unhandled exceptions in Phoenix routes.
+    """
+
+    @events [
+      [:phoenix, :router_dispatch, :exception],
+      [:phoenix, :error_rendered]
+    ]
+
+    @doc """
+    Attaches telemetry handlers for Phoenix error events.
+    Call this once during application startup.
+    """
+    def attach do
+      :telemetry.attach_many(
+        "scout-apm-phoenix-error-telemetry",
+        @events,
+        &__MODULE__.handle_event/4,
+        nil
+      )
+    end
+
+    @doc """
+    Detaches the telemetry handlers. Useful for testing.
+    """
+    def detach do
+      :telemetry.detach("scout-apm-phoenix-error-telemetry")
+    end
+
+    # Router dispatch exception - captures full exception info
+    def handle_event(
+          [:phoenix, :router_dispatch, :exception],
+          _measurements,
+          %{conn: conn, kind: kind, reason: reason, stacktrace: stacktrace} = _metadata,
+          _config
+        ) do
+      # Also mark the tracked request as having an error
+      ScoutApm.TrackedRequest.mark_error()
+
+      # Extract request information from conn
+      opts = [
+        request_path: conn.request_path,
+        request_params: extract_params(conn),
+        session: extract_session(conn),
+        custom_controller: extract_controller(conn)
+      ]
+
+      ScoutApm.Error.capture_from_telemetry(kind, reason, stacktrace, opts)
+    end
+
+    # Error rendered - captures when Phoenix renders an error response
+    # This is useful for catching errors that bubble up to the error view
+    def handle_event(
+          [:phoenix, :error_rendered],
+          _measurements,
+          %{status: status, kind: kind, reason: reason, stacktrace: stacktrace} = metadata,
+          _config
+        )
+        when status >= 500 do
+      conn = Map.get(metadata, :conn)
+
+      opts =
+        if conn do
+          [
+            request_path: conn.request_path,
+            request_params: extract_params(conn),
+            session: extract_session(conn),
+            custom_controller: extract_controller(conn)
+          ]
+        else
+          []
+        end
+
+      ScoutApm.Error.capture_from_telemetry(kind, reason, stacktrace, opts)
+    end
+
+    def handle_event([:phoenix, :error_rendered], _measurements, _metadata, _config) do
+      # Ignore non-500 errors (4xx client errors)
+      :ok
+    end
+
+    # Catch-all for unhandled events
+    def handle_event(_event, _measurements, _metadata, _config), do: :ok
+
+    # Private helpers
+
+    defp extract_params(conn) do
+      try do
+        conn.params
+      rescue
+        _ -> nil
+      end
+    end
+
+    defp extract_session(conn) do
+      try do
+        Plug.Conn.get_session(conn)
+      rescue
+        _ -> nil
+      end
+    end
+
+    defp extract_controller(conn) do
+      controller = conn.private[:phoenix_controller]
+      action = conn.private[:phoenix_action]
+
+      if controller do
+        controller_name =
+          controller
+          |> Module.split()
+          |> Enum.drop(1)
+          |> Enum.join(".")
+
+        if action do
+          "#{controller_name}##{action}"
+        else
+          controller_name
+        end
+      else
+        nil
+      end
+    end
+  end
+end

--- a/lib/scout_apm/tracing.ex
+++ b/lib/scout_apm/tracing.ex
@@ -105,9 +105,10 @@ defmodule ScoutApm.Tracing do
       try do
         (fn -> unquote(block) end).()
       rescue
-        e in RuntimeError ->
-          # TODO - Add real error tracking
-          raise e
+        e ->
+          ScoutApm.Error.capture(e, stacktrace: __STACKTRACE__)
+          TrackedRequest.mark_error()
+          reraise e, __STACKTRACE__
       after
         TrackedRequest.stop_layer()
       end

--- a/test/scout_apm/error/error_data_test.exs
+++ b/test/scout_apm/error/error_data_test.exs
@@ -1,0 +1,150 @@
+defmodule ScoutApm.Error.ErrorDataTest do
+  use ExUnit.Case
+
+  alias ScoutApm.Error.ErrorData
+
+  describe "from_exception/2" do
+    test "creates error data from an exception" do
+      exception = %RuntimeError{message: "Something went wrong"}
+      error_data = ErrorData.from_exception(exception)
+
+      assert error_data.exception_class == "RuntimeError"
+      assert error_data.message == "Something went wrong"
+      assert is_binary(error_data.request_id)
+      assert is_list(error_data.trace)
+      assert error_data.host != nil
+    end
+
+    test "includes stacktrace when provided" do
+      exception = %RuntimeError{message: "test"}
+
+      try do
+        raise exception
+      rescue
+        e ->
+          error_data = ErrorData.from_exception(e, stacktrace: __STACKTRACE__)
+          assert length(error_data.trace) > 0
+          assert Enum.any?(error_data.trace, &String.contains?(&1, "error_data_test.exs"))
+      end
+    end
+
+    test "includes request path when provided" do
+      exception = %RuntimeError{message: "test"}
+      error_data = ErrorData.from_exception(exception, request_path: "/api/users")
+
+      assert error_data.request_uri == "/api/users"
+    end
+
+    test "filters request params" do
+      exception = %RuntimeError{message: "test"}
+
+      error_data =
+        ErrorData.from_exception(exception,
+          request_params: %{"password" => "secret", "name" => "john"}
+        )
+
+      assert error_data.request_params["password"] == "[FILTERED]"
+      assert error_data.request_params["name"] == "john"
+    end
+
+    test "includes custom controller" do
+      exception = %RuntimeError{message: "test"}
+      error_data = ErrorData.from_exception(exception, custom_controller: "UserController#show")
+
+      assert error_data.request_components["controller"] == "UserController#show"
+    end
+
+    test "includes user-provided context" do
+      exception = %RuntimeError{message: "test"}
+      error_data = ErrorData.from_exception(exception, context: %{user_id: 123})
+
+      assert error_data.context[:user_id] == 123
+    end
+
+    test "includes custom params" do
+      exception = %RuntimeError{message: "test"}
+      error_data = ErrorData.from_exception(exception, custom_params: %{extra: "data"})
+
+      assert error_data.context["custom_params"][:extra] == "data"
+    end
+  end
+
+  describe "from_telemetry/4" do
+    test "handles :error kind with exception" do
+      exception = %ArgumentError{message: "invalid argument"}
+      stacktrace = [{__MODULE__, :test, 0, [file: ~c"test.ex", line: 1]}]
+
+      error_data = ErrorData.from_telemetry(:error, exception, stacktrace, [])
+
+      assert error_data.exception_class == "ArgumentError"
+      assert error_data.message == "invalid argument"
+    end
+
+    test "handles :error kind with non-exception reason" do
+      stacktrace = [{__MODULE__, :test, 0, [file: ~c"test.ex", line: 1]}]
+
+      error_data = ErrorData.from_telemetry(:error, {:badmatch, :something}, stacktrace, [])
+
+      assert error_data.exception_class == "ErlangError"
+      assert error_data.message =~ "badmatch"
+    end
+
+    test "handles :throw kind" do
+      stacktrace = [{__MODULE__, :test, 0, [file: ~c"test.ex", line: 1]}]
+
+      error_data = ErrorData.from_telemetry(:throw, "thrown value", stacktrace, [])
+
+      assert error_data.exception_class == "ThrowError"
+      assert error_data.message =~ "thrown value"
+    end
+
+    test "handles :exit kind" do
+      stacktrace = [{__MODULE__, :test, 0, [file: ~c"test.ex", line: 1]}]
+
+      error_data = ErrorData.from_telemetry(:exit, :normal, stacktrace, [])
+
+      assert error_data.exception_class == "ExitError"
+      assert error_data.message =~ "normal"
+    end
+
+    test "includes options" do
+      exception = %RuntimeError{message: "test"}
+      stacktrace = [{__MODULE__, :test, 0, [file: ~c"test.ex", line: 1]}]
+
+      error_data =
+        ErrorData.from_telemetry(:error, exception, stacktrace,
+          request_path: "/test",
+          custom_controller: "TestController"
+        )
+
+      assert error_data.request_uri == "/test"
+      assert error_data.request_components["controller"] == "TestController"
+    end
+  end
+
+  describe "to_map/1" do
+    test "converts error data to a map" do
+      exception = %RuntimeError{message: "test error"}
+      error_data = ErrorData.from_exception(exception, request_path: "/test")
+
+      map = ErrorData.to_map(error_data)
+
+      assert map["exception_class"] == "RuntimeError"
+      assert map["message"] == "test error"
+      assert map["request_uri"] == "/test"
+      assert is_list(map["trace"])
+    end
+
+    test "excludes nil values" do
+      exception = %RuntimeError{message: "test"}
+      error_data = ErrorData.from_exception(exception)
+
+      map = ErrorData.to_map(error_data)
+
+      # request_params should not be present if nil
+      refute Map.has_key?(map, "request_params")
+      refute Map.has_key?(map, "request_session")
+      refute Map.has_key?(map, "environment")
+    end
+  end
+end

--- a/test/scout_apm/error/error_service_test.exs
+++ b/test/scout_apm/error/error_service_test.exs
@@ -1,0 +1,38 @@
+defmodule ScoutApm.Error.ErrorServiceTest do
+  use ExUnit.Case
+
+  alias ScoutApm.Error.ErrorData
+  alias ScoutApm.Error.ErrorService
+
+  # The ErrorService is started by the application, so we don't need to start it here
+
+  describe "send/1" do
+    test "accepts error data and returns :ok" do
+      error_data =
+        ErrorData.from_exception(%RuntimeError{message: "test"}, stacktrace: [])
+
+      assert ErrorService.send(error_data) == :ok
+    end
+  end
+
+  describe "flush/0" do
+    test "forces immediate flush and returns :ok" do
+      assert ErrorService.flush() == :ok
+    end
+  end
+
+  describe "drain/1" do
+    test "waits for queue to drain and returns :ok" do
+      # Send some errors
+      for i <- 1..3 do
+        error_data =
+          ErrorData.from_exception(%RuntimeError{message: "test #{i}"}, stacktrace: [])
+
+        ErrorService.send(error_data)
+      end
+
+      # Drain should complete
+      assert ErrorService.drain(5000) == :ok
+    end
+  end
+end

--- a/test/scout_apm/error/parameter_filter_test.exs
+++ b/test/scout_apm/error/parameter_filter_test.exs
@@ -1,0 +1,112 @@
+defmodule ScoutApm.Error.ParameterFilterTest do
+  use ExUnit.Case
+
+  alias ScoutApm.Error.ParameterFilter
+
+  describe "filter/1" do
+    test "returns nil for nil input" do
+      assert ParameterFilter.filter(nil) == nil
+    end
+
+    test "filters password keys" do
+      params = %{"password" => "secret123", "username" => "john"}
+      result = ParameterFilter.filter(params)
+
+      assert result["password"] == "[FILTERED]"
+      assert result["username"] == "john"
+    end
+
+    test "filters token keys" do
+      params = %{"token" => "abc123", "auth_token" => "xyz789", "data" => "value"}
+      result = ParameterFilter.filter(params)
+
+      assert result["token"] == "[FILTERED]"
+      assert result["auth_token"] == "[FILTERED]"
+      assert result["data"] == "value"
+    end
+
+    test "filters api_key and apikey" do
+      params = %{"api_key" => "key1", "apikey" => "key2", "public_id" => "123"}
+      result = ParameterFilter.filter(params)
+
+      assert result["api_key"] == "[FILTERED]"
+      assert result["apikey"] == "[FILTERED]"
+      assert result["public_id"] == "123"
+    end
+
+    test "filters secret and secret_key" do
+      params = %{"secret" => "shhh", "secret_key" => "very_secret"}
+      result = ParameterFilter.filter(params)
+
+      assert result["secret"] == "[FILTERED]"
+      assert result["secret_key"] == "[FILTERED]"
+    end
+
+    test "filters credit card related keys" do
+      params = %{"card[number]" => "4111111111111111", "name" => "John"}
+      result = ParameterFilter.filter(params)
+
+      assert result["card[number]"] == "[FILTERED]"
+      assert result["name"] == "John"
+    end
+
+    test "filters case-insensitively" do
+      params = %{"PASSWORD" => "secret", "Password" => "secret2", "pAssWoRd" => "secret3"}
+      result = ParameterFilter.filter(params)
+
+      assert result["PASSWORD"] == "[FILTERED]"
+      assert result["Password"] == "[FILTERED]"
+      assert result["pAssWoRd"] == "[FILTERED]"
+    end
+
+    test "filters nested maps" do
+      params = %{
+        "user" => %{
+          "email" => "test@example.com",
+          "password" => "secret"
+        },
+        "public" => "data"
+      }
+
+      result = ParameterFilter.filter(params)
+
+      assert result["user"]["email"] == "test@example.com"
+      assert result["user"]["password"] == "[FILTERED]"
+      assert result["public"] == "data"
+    end
+
+    test "filters lists" do
+      params = [%{"password" => "secret"}, %{"name" => "john"}]
+      result = ParameterFilter.filter(params)
+
+      assert Enum.at(result, 0)["password"] == "[FILTERED]"
+      assert Enum.at(result, 1)["name"] == "john"
+    end
+
+    test "handles atom keys" do
+      params = %{password: "secret", username: "john"}
+      result = ParameterFilter.filter(params)
+
+      assert result[:password] == "[FILTERED]"
+      assert result[:username] == "john"
+    end
+
+    test "preserves non-sensitive data types" do
+      params = %{
+        "string" => "hello",
+        "number" => 42,
+        "float" => 3.14,
+        "boolean" => true,
+        "atom" => :value
+      }
+
+      result = ParameterFilter.filter(params)
+
+      assert result["string"] == "hello"
+      assert result["number"] == 42
+      assert result["float"] == 3.14
+      assert result["boolean"] == true
+      assert result["atom"] == "value"
+    end
+  end
+end

--- a/test/scout_apm/error_test.exs
+++ b/test/scout_apm/error_test.exs
@@ -1,0 +1,102 @@
+defmodule ScoutApm.ErrorTest do
+  use ExUnit.Case
+
+  describe "capture/2" do
+    test "captures an exception and returns :ok" do
+      exception = %RuntimeError{message: "test error"}
+
+      assert ScoutApm.Error.capture(exception) == :ok
+    end
+
+    test "captures with stacktrace" do
+      try do
+        raise RuntimeError, "test"
+      rescue
+        e ->
+          assert ScoutApm.Error.capture(e, stacktrace: __STACKTRACE__) == :ok
+      end
+    end
+
+    test "captures with additional context" do
+      exception = %RuntimeError{message: "test"}
+
+      result =
+        ScoutApm.Error.capture(exception,
+          context: %{user_id: 123},
+          request_path: "/api/users",
+          request_params: %{"action" => "create"}
+        )
+
+      assert result == :ok
+    end
+
+    test "captures with custom controller" do
+      exception = %RuntimeError{message: "test"}
+
+      result =
+        ScoutApm.Error.capture(exception,
+          custom_controller: "UserController#show"
+        )
+
+      assert result == :ok
+    end
+
+    test "captures with custom params" do
+      exception = %RuntimeError{message: "test"}
+
+      result =
+        ScoutApm.Error.capture(exception,
+          custom_params: %{extra: "data"}
+        )
+
+      assert result == :ok
+    end
+  end
+
+  describe "capture_from_telemetry/4" do
+    test "captures error kind with exception" do
+      exception = %ArgumentError{message: "bad arg"}
+      stacktrace = [{__MODULE__, :test, 0, [file: ~c"test.ex", line: 1]}]
+
+      assert ScoutApm.Error.capture_from_telemetry(:error, exception, stacktrace) == :ok
+    end
+
+    test "captures error kind with non-exception" do
+      stacktrace = [{__MODULE__, :test, 0, [file: ~c"test.ex", line: 1]}]
+
+      assert ScoutApm.Error.capture_from_telemetry(:error, :badarg, stacktrace) == :ok
+    end
+
+    test "captures throw kind" do
+      stacktrace = [{__MODULE__, :test, 0, [file: ~c"test.ex", line: 1]}]
+
+      assert ScoutApm.Error.capture_from_telemetry(:throw, "thrown", stacktrace) == :ok
+    end
+
+    test "captures exit kind" do
+      stacktrace = [{__MODULE__, :test, 0, [file: ~c"test.ex", line: 1]}]
+
+      assert ScoutApm.Error.capture_from_telemetry(:exit, :normal, stacktrace) == :ok
+    end
+
+    test "captures with options" do
+      exception = %RuntimeError{message: "test"}
+      stacktrace = [{__MODULE__, :test, 0, [file: ~c"test.ex", line: 1]}]
+
+      result =
+        ScoutApm.Error.capture_from_telemetry(:error, exception, stacktrace,
+          request_path: "/test",
+          custom_controller: "TestController"
+        )
+
+      assert result == :ok
+    end
+  end
+
+  describe "enabled?/0" do
+    test "returns true when errors are enabled" do
+      # Default config has errors_enabled: true
+      assert ScoutApm.Error.enabled?() == true
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add error capture and reporting to Scout APM's error monitoring service
- Capture errors from Phoenix error telemetry events automatically
- Support manual error reporting via `ScoutApm.Error` module
- Parameter filtering to redact sensitive data from error reports
- ErrorData struct for structured error serialization
- ErrorService GenServer for batched error delivery
- README documentation for error monitoring setup

## Test plan

- [ ] Error data serialization tests pass
- [ ] Parameter filter correctly redacts sensitive fields
- [ ] ErrorService sends batched error reports
- [ ] Phoenix error telemetry integration captures exceptions
- [ ] Manual error reporting via `ScoutApm.Error.capture/2` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)