### PR TITLE
Add log management with OTLP export

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,124 @@ config :scout_apm,
   errors_filter_parameters: ["credit_card", "cvv"]
 ```
 
+## OTLP Logging
+
+Scout APM can capture Elixir Logger messages, enrich them with request context, and send them to an OpenTelemetry collector via OTLP (OpenTelemetry Protocol).
+
+### Setup
+
+1. Enable logging in your configuration:
+
+```elixir
+# config/config.exs
+config :scout_apm,
+  logs_enabled: true,
+  logs_ingest_key: "your-logs-ingest-key"  # Or falls back to :key
+```
+
+2. Attach the log handler in your application startup:
+
+```elixir
+# In your application.ex start/2
+def start(_type, _args) do
+  ScoutApm.Logging.attach()
+  # ... rest of supervision tree
+end
+```
+
+### Automatic Context Enrichment
+
+Logs captured within Scout-tracked requests are automatically enriched with:
+
+- `scout.request_id` - Unique request identifier for correlation
+- `scout.transaction_name` - e.g., "Controller/UsersController#show"
+- `scout.layer_type` - Current operation type (Controller, Ecto, etc.)
+- `scout.layer_name` - Current operation name
+- `scout.has_error` - Whether the request has encountered an error
+- `scout.tag.{key}` - Custom tags from `ScoutApm.Context.add/2`
+- `scout.user.{key}` - User context from `ScoutApm.Context.add_user/2`
+- `service.name` - Application name from config
+
+Example - logs are automatically enriched when inside a Scout-tracked request:
+
+```elixir
+def show(conn, %{"id" => id}) do
+  user = Repo.get!(User, id)
+  Logger.info("Fetched user", user_id: id)  # Includes Scout context automatically
+  render(conn, :show, user: user)
+end
+```
+
+### Custom Context
+
+Add custom context that appears in your logs:
+
+```elixir
+ScoutApm.Context.add("feature_flag", "new_checkout")
+ScoutApm.Context.add_user("id", current_user.id)
+
+Logger.info("Processing checkout")  # Includes scout.tag.feature_flag and scout.user.id
+```
+
+### Configuration
+
+```elixir
+config :scout_apm,
+  # Enable/disable log capture (default: false, opt-in)
+  logs_enabled: true,
+
+  # OTLP collector endpoint
+  logs_endpoint: "https://otlp.scoutotel.com:4318",
+
+  # Authentication key (falls back to :key if not set)
+  logs_ingest_key: "your-logs-key",
+
+  # Minimum log level to capture (default: :info)
+  logs_level: :info,
+
+  # Batching settings
+  logs_batch_size: 100,           # Logs per batch (default: 100)
+  logs_max_queue_size: 5000,      # Max queued logs (default: 5000)
+  logs_flush_interval_ms: 5_000,  # Flush interval in ms (default: 5000)
+
+  # Modules to exclude from capture (default: [])
+  logs_filter_modules: [MyApp.VerboseModule]
+```
+
+### Programmatic Control
+
+```elixir
+# Attach with custom options
+ScoutApm.Logging.attach(level: :warning, filter_modules: [MyApp.Noisy])
+
+# Check if attached
+ScoutApm.Logging.attached?()  # => true
+
+# Force flush queued logs
+ScoutApm.Logging.flush()
+
+# Wait for queue to drain (useful for graceful shutdown)
+ScoutApm.Logging.drain(5_000)
+
+# Detach the handler
+ScoutApm.Logging.detach()
+```
+
+### Log Levels
+
+The following Elixir log levels are mapped to OTLP severity:
+
+| Elixir Level | OTLP Severity | OTLP Number |
+|--------------|---------------|-------------|
+| `:debug`     | DEBUG         | 5           |
+| `:info`      | INFO          | 9           |
+| `:notice`    | INFO2         | 11          |
+| `:warning`   | WARN          | 13          |
+| `:error`     | ERROR         | 17          |
+| `:critical`  | FATAL         | 21          |
+| `:alert`     | FATAL         | 21          |
+| `:emergency` | FATAL         | 21          |
+
 ## Development
 
 See [TESTING.md](TESTING.md) for information on testing with different template engine configurations.

--- a/lib/scout_apm/application.ex
+++ b/lib/scout_apm/application.ex
@@ -19,7 +19,9 @@ defmodule ScoutApm.Application do
     :core_agent_log_file,
     :core_agent_config_file,
     :errors_enabled,
-    :errors_host
+    :errors_host,
+    :logs_enabled,
+    :logs_endpoint
   ]
 
   def start(_type, _args) do
@@ -31,7 +33,8 @@ defmodule ScoutApm.Application do
         id: :histogram_watcher
       ),
       collector_module,
-      ScoutApm.Error.ErrorService
+      ScoutApm.Error.ErrorService,
+      ScoutApm.Logging.LogService
     ]
 
     ScoutApm.Cache.setup()

--- a/lib/scout_apm/config.ex
+++ b/lib/scout_apm/config.ex
@@ -41,7 +41,9 @@ defmodule ScoutApm.Config do
   defp coercion(:core_agent_download), do: &Coercions.boolean/1
   defp coercion(:dev_trace), do: &Coercions.boolean/1
   defp coercion(:errors_enabled), do: &Coercions.boolean/1
+  defp coercion(:logs_enabled), do: &Coercions.boolean/1
   defp coercion(:log_level), do: &Coercions.log_level/1
+  defp coercion(:logs_level), do: &Coercions.log_level/1
   defp coercion(:ignore), do: &Coercions.json/1
   defp coercion(_), do: fn x -> {:ok, x} end
 end

--- a/lib/scout_apm/config/defaults.ex
+++ b/lib/scout_apm/config/defaults.ex
@@ -23,7 +23,16 @@ defmodule ScoutApm.Config.Defaults do
       errors_max_queue_size: 500,
       errors_flush_interval_ms: 1_000,
       errors_ignored_exceptions: [],
-      errors_filter_parameters: []
+      errors_filter_parameters: [],
+      # OTLP Logging configuration
+      logs_enabled: false,
+      logs_endpoint: "https://otlp.scoutotel.com:4318",
+      logs_ingest_key: nil,
+      logs_batch_size: 100,
+      logs_max_queue_size: 5000,
+      logs_flush_interval_ms: 5_000,
+      logs_level: :info,
+      logs_filter_modules: []
     }
   end
 

--- a/lib/scout_apm/logging.ex
+++ b/lib/scout_apm/logging.ex
@@ -1,0 +1,140 @@
+defmodule ScoutApm.Logging do
+  @moduledoc """
+  Public API for Scout APM's OTLP logging integration.
+
+  This module provides functions to capture Elixir Logger messages,
+  enrich them with Scout APM context (request ID, transaction name, custom tags),
+  and send them to an OpenTelemetry collector via OTLP.
+
+  ## Setup
+
+  1. Add configuration to your `config/config.exs`:
+
+      config :scout_apm,
+        logs_enabled: true,
+        logs_ingest_key: "your-logs-key"
+
+  2. Attach the log handler in your application startup:
+
+      def start(_type, _args) do
+        ScoutApm.Logging.attach()
+        # ... rest of supervision tree
+      end
+
+  ## Configuration Options
+
+  - `:logs_enabled` - Enable/disable log capture (default: `false`)
+  - `:logs_endpoint` - OTLP collector URL (default: `"https://otlp.scoutotel.com:4318"`)
+  - `:logs_ingest_key` - Authentication key (falls back to `:key`)
+  - `:logs_level` - Minimum log level to capture (default: `:info`)
+  - `:logs_batch_size` - Logs per batch (default: `100`)
+  - `:logs_max_queue_size` - Maximum queued logs (default: `5000`)
+  - `:logs_flush_interval_ms` - Flush interval in ms (default: `5000`)
+  - `:logs_filter_modules` - List of modules to exclude from capture
+
+  ## Context Enrichment
+
+  Logs captured within Scout-tracked requests are automatically enriched with:
+
+  - `scout.request_id` - Unique request identifier
+  - `scout.transaction_name` - e.g., "Controller/UserController#show"
+  - `scout.layer_type` - Current operation type
+  - `scout.layer_name` - Current operation name
+  - `scout.tag.{key}` - Custom tags from `ScoutApm.Context.add/2`
+  - `scout.user.{key}` - User context from `ScoutApm.Context.add_user/2`
+  - `service.name` - Application name from config
+
+  ## Example
+
+      # Logs are automatically enriched when inside a Scout-tracked request
+      def show(conn, %{"id" => id}) do
+        user = Repo.get!(User, id)
+        Logger.info("Fetched user", user_id: id)  # Will include Scout context
+        render(conn, :show, user: user)
+      end
+
+      # Add custom context that appears in logs
+      ScoutApm.Context.add("feature_flag", "new_checkout")
+      Logger.info("Processing checkout")  # Includes scout.tag.feature_flag
+  """
+
+  alias ScoutApm.Logging.{LogHandler, LogService}
+
+  @doc """
+  Attaches the Scout APM log handler to capture Logger messages.
+
+  ## Options
+
+  - `:level` - Minimum log level to capture (default: from config or `:info`)
+  - `:filter_modules` - Additional modules to exclude from capture
+
+  ## Examples
+
+      # Basic attach
+      ScoutApm.Logging.attach()
+
+      # With options
+      ScoutApm.Logging.attach(level: :warning, filter_modules: [MyApp.Verbose])
+  """
+  @spec attach(keyword()) :: :ok | {:error, term()}
+  def attach(opts \\ []) do
+    LogHandler.attach(opts)
+  end
+
+  @doc """
+  Detaches the Scout APM log handler.
+  Logs will no longer be captured and sent to the OTLP collector.
+  """
+  @spec detach() :: :ok | {:error, term()}
+  def detach do
+    LogHandler.detach()
+  end
+
+  @doc """
+  Returns true if the log handler is currently attached.
+  """
+  @spec attached?() :: boolean()
+  def attached? do
+    LogHandler.attached?()
+  end
+
+  @doc """
+  Returns true if logging is enabled via configuration.
+  """
+  @spec enabled?() :: boolean()
+  def enabled? do
+    LogService.enabled?()
+  end
+
+  @doc """
+  Forces an immediate flush of queued log records.
+  Useful for testing or before application shutdown.
+  """
+  @spec flush() :: :ok
+  def flush do
+    LogService.flush()
+  end
+
+  @doc """
+  Waits for the log queue to drain (all logs sent).
+  Used during testing or graceful shutdown.
+
+  ## Options
+
+  - `timeout` - Maximum time to wait in milliseconds (default: 5000)
+
+  Returns `:ok` if queue is empty, `:timeout` if timeout is reached.
+  """
+  @spec drain(timeout :: non_neg_integer()) :: :ok | :timeout
+  def drain(timeout \\ 5_000) do
+    LogService.drain(timeout)
+  end
+
+  @doc """
+  Returns the current number of queued log records.
+  """
+  @spec queue_size() :: non_neg_integer()
+  def queue_size do
+    LogService.queue_size()
+  end
+end

--- a/lib/scout_apm/logging/context_extractor.ex
+++ b/lib/scout_apm/logging/context_extractor.ex
@@ -1,0 +1,119 @@
+defmodule ScoutApm.Logging.ContextExtractor do
+  @moduledoc """
+  Extracts Scout APM context from the current process for log enrichment.
+
+  Reads from Process.get(:scout_apm_request) to extract:
+  - scout.request_id - TrackedRequest.id
+  - scout.transaction_name - e.g., "Controller/UserController#show"
+  - scout.layer_type - Current layer type
+  - scout.layer_name - Current layer name
+  - scout.tag.{key} - Custom tags from ScoutApm.Context
+  - scout.user.{key} - User context
+  - service.name - From config
+  """
+
+  alias ScoutApm.TrackedRequest
+  alias ScoutApm.Internal.Context
+
+  @doc """
+  Extracts Scout APM context from the current process.
+  Returns a keyword list of context attributes suitable for log enrichment.
+  """
+  @spec extract() :: keyword()
+  def extract do
+    case Process.get(:scout_apm_request) do
+      %TrackedRequest{} = tr ->
+        extract_from_tracked_request(tr)
+
+      _ ->
+        base_context()
+    end
+  end
+
+  @doc """
+  Extracts context from a specific TrackedRequest struct.
+  """
+  @spec extract_from_tracked_request(TrackedRequest.t()) :: keyword()
+  def extract_from_tracked_request(%TrackedRequest{} = tr) do
+    base = base_context()
+
+    request_context = [
+      {"scout.request_id", tr.id},
+      {"scout.transaction_name", get_transaction_name(tr)},
+      {"scout.has_error", tr.error == true}
+    ]
+
+    layer_context = extract_layer_context(tr)
+    custom_context = extract_custom_context(tr.contexts)
+
+    (base ++ request_context ++ layer_context ++ custom_context)
+    |> Enum.filter(fn {_k, v} -> v != nil end)
+  end
+
+  # Private functions
+
+  defp base_context do
+    service_name = ScoutApm.Config.find(:name)
+
+    if service_name do
+      [{"service.name", service_name}]
+    else
+      []
+    end
+  end
+
+  defp get_transaction_name(%TrackedRequest{root_layer: nil}), do: nil
+
+  defp get_transaction_name(%TrackedRequest{root_layer: layer}) do
+    case {layer.type, layer.name} do
+      {type, name} when is_binary(type) and is_binary(name) ->
+        "#{type}/#{name}"
+
+      {type, nil} when is_binary(type) ->
+        type
+
+      _ ->
+        nil
+    end
+  end
+
+  defp extract_layer_context(%TrackedRequest{layers: layers}) when is_list(layers) do
+    case layers do
+      [current | _] ->
+        [
+          {"scout.layer_type", current.type},
+          {"scout.layer_name", current.name}
+        ]
+
+      [] ->
+        []
+    end
+  end
+
+  defp extract_layer_context(_), do: []
+
+  defp extract_custom_context(nil), do: []
+  defp extract_custom_context([]), do: []
+
+  defp extract_custom_context(contexts) when is_list(contexts) do
+    contexts
+    |> Enum.map(&context_to_attribute/1)
+    |> Enum.filter(fn {_k, v} -> v != nil end)
+  end
+
+  defp context_to_attribute(%Context{type: :extra, key: key, value: value}) do
+    {"scout.tag.#{key}", safe_value(value)}
+  end
+
+  defp context_to_attribute(%Context{type: :user, key: key, value: value}) do
+    {"scout.user.#{key}", safe_value(value)}
+  end
+
+  defp context_to_attribute(_), do: {nil, nil}
+
+  defp safe_value(value) when is_binary(value), do: value
+  defp safe_value(value) when is_number(value), do: value
+  defp safe_value(value) when is_boolean(value), do: value
+  defp safe_value(value) when is_atom(value), do: Atom.to_string(value)
+  defp safe_value(value), do: inspect(value, limit: 100)
+end

--- a/lib/scout_apm/logging/log_handler.ex
+++ b/lib/scout_apm/logging/log_handler.ex
@@ -1,0 +1,192 @@
+defmodule ScoutApm.Logging.LogHandler do
+  @moduledoc """
+  Erlang :logger handler for capturing log events and sending them to OTLP.
+
+  This handler runs in the client process (the process that calls Logger),
+  which allows us to directly access Scout APM context from the process dictionary.
+
+  ## Usage
+
+      # Attach the handler
+      ScoutApm.Logging.LogHandler.attach()
+
+      # Detach the handler
+      ScoutApm.Logging.LogHandler.detach()
+
+  ## Configuration
+
+  The handler respects the following config options:
+  - `:logs_enabled` - Must be true for handler to process logs
+  - `:logs_level` - Minimum level to capture (default: :info)
+  - `:logs_filter_modules` - List of modules to exclude from capture
+  """
+
+  alias ScoutApm.Logging.{LogRecord, LogService, ContextExtractor}
+  alias ScoutApm.Logging.OTLP.Severity
+
+  @handler_id :scout_apm_log_handler
+  @recursion_flag :scout_apm_log_handler_active
+
+  # Scout modules to always filter out (prevent recursion)
+  @internal_modules [
+    ScoutApm.Logging.LogHandler,
+    ScoutApm.Logging.LogService,
+    ScoutApm.Logging.OTLP.Exporter,
+    ScoutApm.Logging.OTLP.Encoder,
+    ScoutApm.Logger
+  ]
+
+  @doc """
+  Attaches the log handler to the Erlang :logger system.
+  Returns :ok on success, {:error, reason} on failure.
+  """
+  @spec attach(keyword()) :: :ok | {:error, term()}
+  def attach(opts \\ []) do
+    config = %{
+      level: Keyword.get(opts, :level, get_default_level()),
+      filter_modules: Keyword.get(opts, :filter_modules, get_filter_modules())
+    }
+
+    case :logger.add_handler(@handler_id, __MODULE__, %{config: config}) do
+      :ok ->
+        ScoutApm.Logger.log(:info, "Scout APM log handler attached")
+        :ok
+
+      {:error, {:already_exist, _}} ->
+        :ok
+
+      {:error, reason} = error ->
+        ScoutApm.Logger.log(:debug, "Failed to attach Scout APM log handler: #{inspect(reason)}")
+        error
+    end
+  end
+
+  @doc """
+  Detaches the log handler from the Erlang :logger system.
+  """
+  @spec detach() :: :ok | {:error, term()}
+  def detach do
+    case :logger.remove_handler(@handler_id) do
+      :ok ->
+        ScoutApm.Logger.log(:info, "Scout APM log handler detached")
+        :ok
+
+      {:error, {:not_found, _}} ->
+        :ok
+
+      {:error, reason} = error ->
+        ScoutApm.Logger.log(:debug, "Failed to detach Scout APM log handler: #{inspect(reason)}")
+        error
+    end
+  end
+
+  @doc """
+  Checks if the handler is currently attached.
+  """
+  @spec attached?() :: boolean()
+  def attached? do
+    @handler_id in :logger.get_handler_ids()
+  end
+
+  @doc """
+  Returns the handler ID used for registration.
+  """
+  @spec handler_id() :: atom()
+  def handler_id, do: @handler_id
+
+  # Erlang :logger handler callbacks
+
+  @doc false
+  def adding_handler(config) do
+    {:ok, config}
+  end
+
+  @doc false
+  def removing_handler(_config) do
+    :ok
+  end
+
+  @doc false
+  def changing_config(_action, _old_config, new_config) do
+    {:ok, new_config}
+  end
+
+  # Main callback - receives log events in the client process.
+  # This is where we capture Scout context from the process dictionary.
+  @doc false
+  def log(event, config) do
+    # Prevent recursion - if we're already processing a log, skip
+    if Process.get(@recursion_flag) do
+      :ok
+    else
+      try do
+        Process.put(@recursion_flag, true)
+        do_log(event, config)
+      after
+        Process.delete(@recursion_flag)
+      end
+    end
+  end
+
+  # Private functions
+
+  defp do_log(event, config) do
+    # Check if logging is enabled
+    unless LogService.enabled?() do
+      :ok
+    else
+      handler_config = get_handler_config(config)
+
+      # Check if this event should be processed
+      if should_process?(event, handler_config) do
+        # Extract Scout context from current process
+        scout_context = ContextExtractor.extract()
+
+        # Create log record
+        record = LogRecord.from_logger_event(event, scout_context)
+
+        # Send to service for batching
+        LogService.send(record)
+      end
+
+      :ok
+    end
+  end
+
+  defp get_handler_config(%{config: config}), do: config
+  defp get_handler_config(_), do: %{}
+
+  defp should_process?(event, config) do
+    level = Map.get(event, :level, :info)
+    min_level = Map.get(config, :level, :info)
+    filter_modules = Map.get(config, :filter_modules, [])
+
+    meets_level?(level, min_level) and
+      not from_filtered_module?(event, filter_modules)
+  end
+
+  defp meets_level?(level, min_level) do
+    Severity.meets_level?(level, min_level)
+  end
+
+  defp from_filtered_module?(event, user_filter_modules) do
+    all_filtered = @internal_modules ++ user_filter_modules
+
+    case get_event_module(event) do
+      nil -> false
+      module -> module in all_filtered
+    end
+  end
+
+  defp get_event_module(%{meta: %{mfa: {module, _fun, _arity}}}), do: module
+  defp get_event_module(%{meta: %{module: module}}), do: module
+  defp get_event_module(_), do: nil
+
+  defp get_default_level do
+    ScoutApm.Config.find(:logs_level) || :info
+  end
+
+  defp get_filter_modules do
+    ScoutApm.Config.find(:logs_filter_modules) || []
+  end
+end

--- a/lib/scout_apm/logging/log_record.ex
+++ b/lib/scout_apm/logging/log_record.ex
@@ -1,0 +1,230 @@
+defmodule ScoutApm.Logging.LogRecord do
+  @moduledoc """
+  Internal struct representing a log record to be sent via OTLP.
+
+  Captures all relevant information from an Elixir Logger event
+  and Scout APM context for export to an OTLP collector.
+  """
+
+  @type t :: %__MODULE__{
+          timestamp_nanos: pos_integer(),
+          observed_timestamp_nanos: pos_integer(),
+          severity: atom(),
+          message: String.t(),
+          attributes: map(),
+          trace_id: String.t() | nil,
+          span_id: String.t() | nil,
+          source_location: map() | nil,
+          dropped_attributes_count: non_neg_integer()
+        }
+
+  defstruct [
+    :timestamp_nanos,
+    :observed_timestamp_nanos,
+    :severity,
+    :message,
+    :attributes,
+    :trace_id,
+    :span_id,
+    :source_location,
+    dropped_attributes_count: 0
+  ]
+
+  @max_attributes 128
+  @max_message_length 32_768
+
+  @doc """
+  Creates a new LogRecord from an Erlang :logger event.
+  """
+  @spec from_logger_event(map(), keyword()) :: t()
+  def from_logger_event(event, scout_context \\ []) do
+    now_nanos = System.system_time(:nanosecond)
+
+    # Extract timestamp from event or use current time
+    timestamp_nanos = extract_timestamp(event)
+
+    # Extract severity level
+    severity = Map.get(event, :level, :info)
+
+    # Format the message
+    message = format_message(event)
+
+    # Build attributes from metadata and Scout context
+    {attributes, dropped_count} = build_attributes(event, scout_context)
+
+    # Extract source location if available
+    source_location = extract_source_location(event)
+
+    %__MODULE__{
+      timestamp_nanos: timestamp_nanos,
+      observed_timestamp_nanos: now_nanos,
+      severity: severity,
+      message: message,
+      attributes: attributes,
+      trace_id: Keyword.get(scout_context, :trace_id),
+      span_id: Keyword.get(scout_context, :span_id),
+      source_location: source_location,
+      dropped_attributes_count: dropped_count
+    }
+  end
+
+  @doc """
+  Creates a LogRecord from simple parameters (for testing or direct use).
+  """
+  @spec new(atom(), String.t(), map()) :: t()
+  def new(severity, message, attributes \\ %{}) do
+    now_nanos = System.system_time(:nanosecond)
+    {limited_attrs, dropped_count} = limit_attributes(attributes)
+
+    %__MODULE__{
+      timestamp_nanos: now_nanos,
+      observed_timestamp_nanos: now_nanos,
+      severity: severity,
+      message: truncate_message(message),
+      attributes: limited_attrs,
+      dropped_attributes_count: dropped_count
+    }
+  end
+
+  # Private functions
+
+  defp extract_timestamp(%{meta: %{time: time}}) when is_integer(time) do
+    # Erlang logger time is in microseconds
+    time * 1000
+  end
+
+  defp extract_timestamp(_event) do
+    System.system_time(:nanosecond)
+  end
+
+  defp format_message(%{msg: {:string, msg}}) when is_list(msg) do
+    msg |> IO.iodata_to_binary() |> truncate_message()
+  end
+
+  defp format_message(%{msg: {:string, msg}}) when is_binary(msg) do
+    truncate_message(msg)
+  end
+
+  defp format_message(%{msg: {:report, report}}) do
+    report |> inspect(limit: 500) |> truncate_message()
+  end
+
+  defp format_message(%{msg: {format, args}}) when is_list(args) do
+    try do
+      :io_lib.format(format, args) |> IO.iodata_to_binary() |> truncate_message()
+    rescue
+      _ -> inspect({format, args}) |> truncate_message()
+    end
+  end
+
+  defp format_message(_event) do
+    ""
+  end
+
+  defp truncate_message(msg) when byte_size(msg) > @max_message_length do
+    String.slice(msg, 0, @max_message_length - 3) <> "..."
+  end
+
+  defp truncate_message(msg), do: msg
+
+  defp build_attributes(event, scout_context) do
+    # Start with metadata from the log event
+    metadata_attrs = extract_metadata(event)
+
+    # Add Scout context
+    scout_attrs =
+      scout_context
+      |> Keyword.drop([:trace_id, :span_id])
+      |> Enum.into(%{})
+
+    # Add source location as attributes
+    source_attrs = extract_source_attrs(event)
+
+    # Merge all attributes
+    all_attrs =
+      metadata_attrs
+      |> Map.merge(scout_attrs)
+      |> Map.merge(source_attrs)
+
+    limit_attributes(all_attrs)
+  end
+
+  defp extract_metadata(%{meta: meta}) when is_map(meta) do
+    # Filter out internal logger metadata
+    internal_keys = [:time, :gl, :pid, :file, :line, :mfa, :domain, :error_logger]
+
+    meta
+    |> Map.drop(internal_keys)
+    |> Enum.map(fn {k, v} -> {to_string(k), safe_value(v)} end)
+    |> Enum.into(%{})
+  end
+
+  defp extract_metadata(_), do: %{}
+
+  defp extract_source_attrs(%{meta: %{file: file, line: line, mfa: {mod, fun, arity}}}) do
+    %{
+      "code.filepath" => safe_string(file),
+      "code.lineno" => line,
+      "code.function" => "#{inspect(mod)}.#{fun}/#{arity}"
+    }
+  end
+
+  defp extract_source_attrs(%{meta: %{file: file, line: line}}) do
+    %{
+      "code.filepath" => safe_string(file),
+      "code.lineno" => line
+    }
+  end
+
+  defp extract_source_attrs(_), do: %{}
+
+  defp extract_source_location(%{meta: %{file: file, line: line, mfa: {mod, fun, arity}}}) do
+    %{
+      "file" => safe_string(file),
+      "line" => line,
+      "function" => "#{inspect(mod)}.#{fun}/#{arity}"
+    }
+  end
+
+  defp extract_source_location(%{meta: %{file: file, line: line}}) do
+    %{
+      "file" => safe_string(file),
+      "line" => line
+    }
+  end
+
+  defp extract_source_location(_), do: nil
+
+  defp safe_string(value) when is_list(value), do: List.to_string(value)
+  defp safe_string(value) when is_binary(value), do: value
+  defp safe_string(value), do: inspect(value)
+
+  defp safe_value(value) when is_binary(value), do: value
+  defp safe_value(value) when is_number(value), do: value
+  defp safe_value(value) when is_boolean(value), do: value
+  defp safe_value(value) when is_atom(value), do: Atom.to_string(value)
+  defp safe_value(value) when is_list(value), do: Enum.map(value, &safe_value/1)
+
+  defp safe_value(value) when is_map(value) do
+    value
+    |> Enum.map(fn {k, v} -> {to_string(k), safe_value(v)} end)
+    |> Enum.into(%{})
+  end
+
+  defp safe_value(value), do: inspect(value, limit: 100)
+
+  defp limit_attributes(attrs) when map_size(attrs) <= @max_attributes do
+    {attrs, 0}
+  end
+
+  defp limit_attributes(attrs) do
+    dropped = map_size(attrs) - @max_attributes
+
+    limited =
+      attrs
+      |> Enum.take(@max_attributes)
+      |> Enum.into(%{})
+
+    {limited, dropped}
+  end
+end

--- a/lib/scout_apm/logging/log_service.ex
+++ b/lib/scout_apm/logging/log_service.ex
@@ -1,0 +1,219 @@
+defmodule ScoutApm.Logging.LogService do
+  @moduledoc """
+  Background GenServer that batches and sends log records to an OTLP collector.
+
+  Implements a queue with batching and a maximum queue size to prevent memory issues.
+  Follows the same pattern as ScoutApm.Error.ErrorService.
+  """
+
+  use GenServer
+
+  alias ScoutApm.Logging.LogRecord
+  alias ScoutApm.Logging.OTLP.Exporter
+
+  @default_batch_size 100
+  @default_max_queue_size 5000
+  @default_flush_interval_ms 5_000
+
+  defstruct [
+    :queue,
+    :queue_size,
+    :timer_ref
+  ]
+
+  @type t :: %__MODULE__{
+          queue: :queue.queue(LogRecord.t()),
+          queue_size: non_neg_integer(),
+          timer_ref: reference() | nil
+        }
+
+  # Client API
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Sends a log record to the service for batched delivery.
+  Non-blocking - returns immediately.
+  """
+  @spec send(LogRecord.t()) :: :ok
+  def send(%LogRecord{} = record) do
+    if enabled?() do
+      GenServer.cast(__MODULE__, {:send, record})
+    else
+      :ok
+    end
+  end
+
+  @doc """
+  Waits for the queue to drain. Used in tests and shutdown.
+  """
+  @spec drain(timeout :: non_neg_integer()) :: :ok | :timeout
+  def drain(timeout \\ 5_000) do
+    GenServer.call(__MODULE__, :drain, timeout)
+  catch
+    :exit, _ -> :timeout
+  end
+
+  @doc """
+  Forces an immediate flush of queued logs. Used in tests.
+  """
+  @spec flush() :: :ok
+  def flush do
+    GenServer.call(__MODULE__, :flush)
+  end
+
+  @doc """
+  Returns the current queue size.
+  """
+  @spec queue_size() :: non_neg_integer()
+  def queue_size do
+    GenServer.call(__MODULE__, :queue_size)
+  catch
+    :exit, _ -> 0
+  end
+
+  @doc """
+  Checks if logging is enabled.
+  """
+  @spec enabled?() :: boolean()
+  def enabled? do
+    ScoutApm.Config.find(:logs_enabled) == true
+  end
+
+  # Server Callbacks
+
+  @impl GenServer
+  def init(_opts) do
+    state = %__MODULE__{
+      queue: :queue.new(),
+      queue_size: 0,
+      timer_ref: nil
+    }
+
+    {:ok, schedule_flush(state)}
+  end
+
+  @impl GenServer
+  def handle_cast({:send, %LogRecord{} = record}, state) do
+    max_size = get_max_queue_size()
+
+    if state.queue_size >= max_size do
+      ScoutApm.Logger.log(:debug, "Log queue full (#{max_size}), dropping log record")
+      {:noreply, state}
+    else
+      new_queue = :queue.in(record, state.queue)
+      new_state = %{state | queue: new_queue, queue_size: state.queue_size + 1}
+
+      # If we've hit batch size, flush immediately
+      if new_state.queue_size >= get_batch_size() do
+        {:noreply, do_flush(new_state)}
+      else
+        {:noreply, new_state}
+      end
+    end
+  end
+
+  @impl GenServer
+  def handle_call(:drain, _from, state) do
+    new_state = drain_all(state)
+    {:reply, :ok, new_state}
+  end
+
+  @impl GenServer
+  def handle_call(:flush, _from, state) do
+    new_state = do_flush(state)
+    {:reply, :ok, new_state}
+  end
+
+  @impl GenServer
+  def handle_call(:queue_size, _from, state) do
+    {:reply, state.queue_size, state}
+  end
+
+  @impl GenServer
+  def handle_info(:flush, state) do
+    new_state =
+      state
+      |> do_flush()
+      |> schedule_flush()
+
+    {:noreply, new_state}
+  end
+
+  @impl GenServer
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    drain_all(state)
+    :ok
+  end
+
+  # Private Functions
+
+  defp schedule_flush(state) do
+    if state.timer_ref, do: Process.cancel_timer(state.timer_ref)
+
+    timer_ref = Process.send_after(self(), :flush, get_flush_interval())
+    %{state | timer_ref: timer_ref}
+  end
+
+  defp do_flush(%{queue_size: 0} = state), do: state
+
+  defp do_flush(state) do
+    batch_size = get_batch_size()
+
+    {records, remaining_queue, remaining_size} =
+      dequeue_batch(state.queue, state.queue_size, batch_size)
+
+    if length(records) > 0 do
+      Task.start(fn -> Exporter.export(records) end)
+    end
+
+    %{state | queue: remaining_queue, queue_size: remaining_size}
+  end
+
+  defp drain_all(%{queue_size: 0} = state), do: state
+
+  defp drain_all(state) do
+    {records, remaining_queue, remaining_size} =
+      dequeue_batch(state.queue, state.queue_size, state.queue_size)
+
+    if length(records) > 0 do
+      # Send synchronously during drain
+      Exporter.export(records)
+    end
+
+    %{state | queue: remaining_queue, queue_size: remaining_size}
+  end
+
+  defp dequeue_batch(queue, queue_size, batch_size) do
+    count = min(batch_size, queue_size)
+
+    {records, new_queue} =
+      Enum.reduce(1..max(count, 1), {[], queue}, fn
+        _, {acc, q} when length(acc) >= count ->
+          {acc, q}
+
+        _, {acc, q} ->
+          case :queue.out(q) do
+            {{:value, record}, new_q} -> {[record | acc], new_q}
+            {:empty, q} -> {acc, q}
+          end
+      end)
+
+    {Enum.reverse(records), new_queue, queue_size - length(records)}
+  end
+
+  defp get_batch_size, do: ScoutApm.Config.find(:logs_batch_size) || @default_batch_size
+
+  defp get_max_queue_size,
+    do: ScoutApm.Config.find(:logs_max_queue_size) || @default_max_queue_size
+
+  defp get_flush_interval,
+    do: ScoutApm.Config.find(:logs_flush_interval_ms) || @default_flush_interval_ms
+end

--- a/lib/scout_apm/logging/otlp/encoder.ex
+++ b/lib/scout_apm/logging/otlp/encoder.ex
@@ -1,0 +1,198 @@
+defmodule ScoutApm.Logging.OTLP.Encoder do
+  @moduledoc """
+  Encodes log records into OTLP JSON format.
+
+  Builds the full OTLP structure:
+  {
+    "resourceLogs": [{
+      "resource": { "attributes": [...] },
+      "scopeLogs": [{
+        "scope": { "name": "scout_apm_elixir", "version": "..." },
+        "logRecords": [...]
+      }]
+    }]
+  }
+  """
+
+  alias ScoutApm.Logging.OTLP.{Resource, Severity}
+  alias ScoutApm.Logging.LogRecord
+
+  @scope_name "scout_apm_elixir"
+
+  @doc """
+  Encodes a list of LogRecord structs into OTLP JSON format.
+  """
+  @spec encode([LogRecord.t()]) :: map()
+  def encode(log_records) when is_list(log_records) do
+    %{
+      "resourceLogs" => [
+        %{
+          "resource" => %{
+            "attributes" => Resource.build()
+          },
+          "scopeLogs" => [
+            %{
+              "scope" => build_scope(),
+              "logRecords" => Enum.map(log_records, &encode_log_record/1)
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+  @doc """
+  Encodes a single LogRecord struct into OTLP format.
+  """
+  @spec encode_log_record(LogRecord.t()) :: map()
+  def encode_log_record(%LogRecord{} = record) do
+    base = %{
+      "timeUnixNano" => to_string(record.timestamp_nanos),
+      "observedTimeUnixNano" => to_string(record.observed_timestamp_nanos),
+      "severityNumber" => Severity.to_number(record.severity),
+      "severityText" => Severity.to_text(record.severity),
+      "body" => encode_body(record.message)
+    }
+
+    base
+    |> maybe_add_attributes(record.attributes)
+    |> maybe_add_trace_context(record)
+    |> maybe_add_dropped_count(record.dropped_attributes_count)
+  end
+
+  # Private functions
+
+  defp build_scope do
+    %{
+      "name" => @scope_name,
+      "version" => get_version()
+    }
+  end
+
+  defp get_version do
+    case :application.get_key(:scout_apm, :vsn) do
+      {:ok, vsn} -> List.to_string(vsn)
+      _ -> "unknown"
+    end
+  end
+
+  defp encode_body(message) when is_binary(message) do
+    %{"stringValue" => message}
+  end
+
+  defp encode_body(message) do
+    %{"stringValue" => inspect(message)}
+  end
+
+  defp maybe_add_attributes(map, nil), do: map
+  defp maybe_add_attributes(map, attributes) when map_size(attributes) == 0, do: map
+
+  defp maybe_add_attributes(map, attributes) do
+    encoded_attrs =
+      attributes
+      |> Enum.map(&encode_attribute/1)
+      |> Enum.reject(&is_nil/1)
+
+    if length(encoded_attrs) > 0 do
+      Map.put(map, "attributes", encoded_attrs)
+    else
+      map
+    end
+  end
+
+  defp encode_attribute({key, value}) when is_binary(key) do
+    encode_attribute_value(key, value)
+  end
+
+  defp encode_attribute({key, value}) when is_atom(key) do
+    encode_attribute_value(Atom.to_string(key), value)
+  end
+
+  defp encode_attribute(_), do: nil
+
+  defp encode_attribute_value(key, value) when is_binary(value) do
+    %{"key" => key, "value" => %{"stringValue" => value}}
+  end
+
+  defp encode_attribute_value(key, value) when is_integer(value) do
+    %{"key" => key, "value" => %{"intValue" => to_string(value)}}
+  end
+
+  defp encode_attribute_value(key, value) when is_float(value) do
+    %{"key" => key, "value" => %{"doubleValue" => value}}
+  end
+
+  defp encode_attribute_value(key, value) when is_boolean(value) do
+    %{"key" => key, "value" => %{"boolValue" => value}}
+  end
+
+  defp encode_attribute_value(key, value) when is_atom(value) do
+    %{"key" => key, "value" => %{"stringValue" => Atom.to_string(value)}}
+  end
+
+  defp encode_attribute_value(key, value) when is_list(value) do
+    # Encode as array value
+    encoded_values =
+      value
+      |> Enum.map(&encode_array_value/1)
+      |> Enum.reject(&is_nil/1)
+
+    %{"key" => key, "value" => %{"arrayValue" => %{"values" => encoded_values}}}
+  end
+
+  defp encode_attribute_value(key, value) when is_map(value) do
+    # Encode map as JSON string for simplicity
+    case Jason.encode(value) do
+      {:ok, json} -> %{"key" => key, "value" => %{"stringValue" => json}}
+      _ -> %{"key" => key, "value" => %{"stringValue" => inspect(value)}}
+    end
+  end
+
+  defp encode_attribute_value(key, value) do
+    %{"key" => key, "value" => %{"stringValue" => inspect(value)}}
+  end
+
+  defp encode_array_value(value) when is_binary(value), do: %{"stringValue" => value}
+  defp encode_array_value(value) when is_integer(value), do: %{"intValue" => to_string(value)}
+  defp encode_array_value(value) when is_float(value), do: %{"doubleValue" => value}
+  defp encode_array_value(value) when is_boolean(value), do: %{"boolValue" => value}
+
+  defp encode_array_value(value) when is_atom(value),
+    do: %{"stringValue" => Atom.to_string(value)}
+
+  defp encode_array_value(value), do: %{"stringValue" => inspect(value)}
+
+  defp maybe_add_trace_context(map, %LogRecord{trace_id: nil}), do: map
+  defp maybe_add_trace_context(map, %LogRecord{span_id: nil}), do: map
+
+  defp maybe_add_trace_context(map, %LogRecord{trace_id: trace_id, span_id: span_id}) do
+    map
+    |> Map.put("traceId", encode_trace_id(trace_id))
+    |> Map.put("spanId", encode_span_id(span_id))
+  end
+
+  defp encode_trace_id(trace_id) when is_binary(trace_id), do: trace_id
+
+  defp encode_trace_id(trace_id) when is_integer(trace_id) do
+    trace_id
+    |> Integer.to_string(16)
+    |> String.downcase()
+    |> String.pad_leading(32, "0")
+  end
+
+  defp encode_span_id(span_id) when is_binary(span_id), do: span_id
+
+  defp encode_span_id(span_id) when is_integer(span_id) do
+    span_id
+    |> Integer.to_string(16)
+    |> String.downcase()
+    |> String.pad_leading(16, "0")
+  end
+
+  defp maybe_add_dropped_count(map, nil), do: map
+  defp maybe_add_dropped_count(map, 0), do: map
+
+  defp maybe_add_dropped_count(map, count) do
+    Map.put(map, "droppedAttributesCount", count)
+  end
+end

--- a/lib/scout_apm/logging/otlp/exporter.ex
+++ b/lib/scout_apm/logging/otlp/exporter.ex
@@ -1,0 +1,105 @@
+defmodule ScoutApm.Logging.OTLP.Exporter do
+  @moduledoc """
+  HTTP transport for sending logs to an OTLP collector.
+
+  Sends log records via HTTP POST to the /v1/logs endpoint.
+  Supports gzip compression for payloads over 1KB.
+  """
+
+  alias ScoutApm.Logging.OTLP.Encoder
+  alias ScoutApm.Logging.LogRecord
+
+  @logs_endpoint "/v1/logs"
+  @compression_threshold 1024
+
+  @doc """
+  Exports a batch of log records to the configured OTLP endpoint.
+  Returns :ok on success or {:error, reason} on failure.
+  """
+  @spec export([LogRecord.t()]) :: :ok | {:error, term()}
+  def export([]), do: :ok
+
+  def export(log_records) when is_list(log_records) do
+    payload = Encoder.encode(log_records)
+
+    case Jason.encode(payload) do
+      {:ok, json} ->
+        {body, content_encoding} = maybe_compress(json)
+        do_http_send(body, content_encoding, length(log_records))
+
+      {:error, reason} ->
+        ScoutApm.Logger.log(:debug, "Failed to encode log payload: #{inspect(reason)}")
+        {:error, {:encode_error, reason}}
+    end
+  end
+
+  # Private functions
+
+  defp maybe_compress(json) when byte_size(json) > @compression_threshold do
+    {:zlib.gzip(json), "gzip"}
+  end
+
+  defp maybe_compress(json) do
+    {json, nil}
+  end
+
+  defp do_http_send(body, content_encoding, log_count) do
+    url = build_url()
+    headers = build_headers(content_encoding)
+
+    case :hackney.request(:post, url, headers, body, [:with_body]) do
+      {:ok, status, _headers, _body} when status < 300 ->
+        ScoutApm.Logger.log(:debug, "Successfully sent #{log_count} logs to OTLP collector")
+        :ok
+
+      {:ok, status, _headers, response_body} ->
+        ScoutApm.Logger.log(
+          :debug,
+          "Error sending logs to OTLP collector. Status: #{status}, Body: #{inspect(response_body)}"
+        )
+
+        {:error, {:http_error, status}}
+
+      {:error, reason} ->
+        ScoutApm.Logger.log(:debug, "Error sending logs to OTLP collector: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  defp build_url do
+    endpoint = get_endpoint()
+
+    # Ensure endpoint doesn't have trailing slash
+    endpoint = String.trim_trailing(endpoint, "/")
+    "#{endpoint}#{@logs_endpoint}"
+  end
+
+  defp get_endpoint do
+    ScoutApm.Config.find(:logs_endpoint) || "https://otlp.scoutotel.com:4318"
+  end
+
+  defp build_headers(content_encoding) do
+    base_headers = [
+      {"Content-Type", "application/json"},
+      {"x-scout-key", get_ingest_key()},
+      {"User-Agent", "scout_apm_elixir/#{get_version()}"}
+    ]
+
+    if content_encoding do
+      [{"Content-Encoding", content_encoding} | base_headers]
+    else
+      base_headers
+    end
+  end
+
+  defp get_ingest_key do
+    ScoutApm.Config.find(:logs_ingest_key) || ScoutApm.Config.find(:key) || ""
+  end
+
+  defp get_version do
+    case :application.get_key(:scout_apm, :vsn) do
+      {:ok, vsn} -> List.to_string(vsn)
+      _ -> "unknown"
+    end
+  end
+end

--- a/lib/scout_apm/logging/otlp/resource.ex
+++ b/lib/scout_apm/logging/otlp/resource.ex
@@ -1,0 +1,113 @@
+defmodule ScoutApm.Logging.OTLP.Resource do
+  @moduledoc """
+  Builds OTLP Resource attributes for log records.
+
+  The Resource represents the entity producing telemetry and includes
+  attributes like service name, version, host, and environment.
+  """
+
+  @doc """
+  Builds the resource attributes map for OTLP export.
+  Returns a list of attribute maps in OTLP format.
+  """
+  @spec build() :: [map()]
+  def build do
+    attributes = [
+      {"service.name", get_service_name()},
+      {"service.version", get_service_version()},
+      {"telemetry.sdk.name", "scout_apm_elixir"},
+      {"telemetry.sdk.version", get_sdk_version()},
+      {"telemetry.sdk.language", "elixir"},
+      {"host.name", get_hostname()},
+      {"deployment.environment", get_environment()}
+    ]
+
+    attributes
+    |> Enum.filter(fn {_key, value} -> value != nil and value != "" end)
+    |> Enum.map(&to_otlp_attribute/1)
+  end
+
+  @doc """
+  Converts a {key, value} tuple to OTLP attribute format.
+  """
+  @spec to_otlp_attribute({String.t(), any()}) :: map()
+  def to_otlp_attribute({key, value}) when is_binary(value) do
+    %{"key" => key, "value" => %{"stringValue" => value}}
+  end
+
+  def to_otlp_attribute({key, value}) when is_integer(value) do
+    %{"key" => key, "value" => %{"intValue" => to_string(value)}}
+  end
+
+  def to_otlp_attribute({key, value}) when is_float(value) do
+    %{"key" => key, "value" => %{"doubleValue" => value}}
+  end
+
+  def to_otlp_attribute({key, value}) when is_boolean(value) do
+    %{"key" => key, "value" => %{"boolValue" => value}}
+  end
+
+  def to_otlp_attribute({key, value}) when is_atom(value) do
+    %{"key" => key, "value" => %{"stringValue" => Atom.to_string(value)}}
+  end
+
+  def to_otlp_attribute({key, value}) do
+    %{"key" => key, "value" => %{"stringValue" => inspect(value)}}
+  end
+
+  # Private functions
+
+  defp get_service_name do
+    ScoutApm.Config.find(:name) || get_app_name()
+  end
+
+  defp get_app_name do
+    case Application.get_application(__MODULE__) do
+      nil -> "unknown"
+      app -> Atom.to_string(app)
+    end
+  end
+
+  defp get_service_version do
+    ScoutApm.Config.find(:revision_sha) || get_app_version()
+  end
+
+  defp get_app_version do
+    case :application.get_key(:scout_apm, :vsn) do
+      {:ok, vsn} -> List.to_string(vsn)
+      _ -> nil
+    end
+  end
+
+  defp get_sdk_version do
+    case :application.get_key(:scout_apm, :vsn) do
+      {:ok, vsn} -> List.to_string(vsn)
+      _ -> "unknown"
+    end
+  end
+
+  defp get_hostname do
+    ScoutApm.Cache.hostname() || get_system_hostname()
+  end
+
+  defp get_system_hostname do
+    case :inet.gethostname() do
+      {:ok, hostname} -> List.to_string(hostname)
+      _ -> nil
+    end
+  end
+
+  defp get_environment do
+    case ScoutApm.Config.find(:environment) do
+      nil ->
+        if function_exported?(Mix, :env, 0) do
+          Mix.env() |> to_string()
+        else
+          "production"
+        end
+
+      env ->
+        to_string(env)
+    end
+  end
+end

--- a/lib/scout_apm/logging/otlp/severity.ex
+++ b/lib/scout_apm/logging/otlp/severity.ex
@@ -1,0 +1,63 @@
+defmodule ScoutApm.Logging.OTLP.Severity do
+  @moduledoc """
+  Maps Elixir Logger levels to OpenTelemetry severity numbers and text.
+
+  OTLP Severity Numbers (from OpenTelemetry specification):
+  - 1-4:   TRACE
+  - 5-8:   DEBUG
+  - 9-12:  INFO
+  - 13-16: WARN
+  - 17-20: ERROR
+  - 21-24: FATAL
+  """
+
+  @type level ::
+          :emergency | :alert | :critical | :error | :warning | :warn | :notice | :info | :debug
+
+  @doc """
+  Converts an Elixir Logger level to an OTLP severity number.
+  """
+  @spec to_number(level()) :: pos_integer()
+  def to_number(:emergency), do: 21
+  def to_number(:alert), do: 21
+  def to_number(:critical), do: 21
+  def to_number(:error), do: 17
+  def to_number(:warning), do: 13
+  def to_number(:warn), do: 13
+  def to_number(:notice), do: 11
+  def to_number(:info), do: 9
+  def to_number(:debug), do: 5
+  def to_number(_), do: 0
+
+  @doc """
+  Converts an Elixir Logger level to an OTLP severity text string.
+  """
+  @spec to_text(level()) :: String.t()
+  def to_text(:emergency), do: "FATAL"
+  def to_text(:alert), do: "FATAL"
+  def to_text(:critical), do: "FATAL"
+  def to_text(:error), do: "ERROR"
+  def to_text(:warning), do: "WARN"
+  def to_text(:warn), do: "WARN"
+  def to_text(:notice), do: "INFO2"
+  def to_text(:info), do: "INFO"
+  def to_text(:debug), do: "DEBUG"
+  def to_text(_), do: "UNSPECIFIED"
+
+  @doc """
+  Compares two log levels. Returns true if level1 is at or above level2.
+  Used for filtering logs by minimum level.
+  """
+  @spec meets_level?(level(), level()) :: boolean()
+  def meets_level?(level1, level2) do
+    to_number(level1) >= to_number(level2)
+  end
+
+  @doc """
+  Returns the list of all supported Elixir log levels in order of severity (highest first).
+  """
+  @spec levels() :: [level()]
+  def levels do
+    [:emergency, :alert, :critical, :error, :warning, :notice, :info, :debug]
+  end
+end

--- a/test/scout_apm/logging/context_extractor_test.exs
+++ b/test/scout_apm/logging/context_extractor_test.exs
@@ -1,0 +1,136 @@
+defmodule ScoutApm.Logging.ContextExtractorTest do
+  use ExUnit.Case
+
+  alias ScoutApm.Logging.ContextExtractor
+  alias ScoutApm.TrackedRequest
+  alias ScoutApm.Internal.Context
+
+  describe "extract/0" do
+    test "returns empty context when no tracked request" do
+      # Make sure there's no tracked request
+      Process.delete(:scout_apm_request)
+
+      context = ContextExtractor.extract()
+
+      # Should only have service.name if configured
+      assert is_list(context)
+    end
+
+    test "extracts context from tracked request" do
+      # Create a tracked request with some data
+      tr = %TrackedRequest{
+        id: "test-request-123",
+        root_layer: %ScoutApm.Internal.Layer{
+          type: "Controller",
+          name: "UsersController#show",
+          started_at: NaiveDateTime.utc_now(),
+          children: []
+        },
+        layers: [],
+        children: [],
+        contexts: [],
+        collector_fn: nil,
+        error: false,
+        ignored: false,
+        ignoring_depth: 0
+      }
+
+      Process.put(:scout_apm_request, tr)
+
+      try do
+        context = ContextExtractor.extract()
+
+        # Find the request_id in context
+        request_id =
+          Enum.find_value(context, fn
+            {"scout.request_id", v} -> v
+            _ -> nil
+          end)
+
+        assert request_id == "test-request-123"
+
+        # Find transaction name
+        tx_name =
+          Enum.find_value(context, fn
+            {"scout.transaction_name", v} -> v
+            _ -> nil
+          end)
+
+        assert tx_name == "Controller/UsersController#show"
+      after
+        Process.delete(:scout_apm_request)
+      end
+    end
+
+    test "extracts custom context tags" do
+      tr = %TrackedRequest{
+        id: "test-123",
+        root_layer: nil,
+        layers: [],
+        children: [],
+        contexts: [
+          %Context{type: :extra, key: "feature", value: "checkout"},
+          %Context{type: :user, key: "id", value: "user-456"}
+        ],
+        collector_fn: nil,
+        error: false,
+        ignored: false,
+        ignoring_depth: 0
+      }
+
+      Process.put(:scout_apm_request, tr)
+
+      try do
+        context = ContextExtractor.extract()
+
+        tag_value =
+          Enum.find_value(context, fn
+            {"scout.tag.feature", v} -> v
+            _ -> nil
+          end)
+
+        assert tag_value == "checkout"
+
+        user_value =
+          Enum.find_value(context, fn
+            {"scout.user.id", v} -> v
+            _ -> nil
+          end)
+
+        assert user_value == "user-456"
+      after
+        Process.delete(:scout_apm_request)
+      end
+    end
+
+    test "includes error flag when request has error" do
+      tr = %TrackedRequest{
+        id: "test-123",
+        root_layer: nil,
+        layers: [],
+        children: [],
+        contexts: [],
+        collector_fn: nil,
+        error: true,
+        ignored: false,
+        ignoring_depth: 0
+      }
+
+      Process.put(:scout_apm_request, tr)
+
+      try do
+        context = ContextExtractor.extract()
+
+        has_error =
+          Enum.find_value(context, fn
+            {"scout.has_error", v} -> v
+            _ -> nil
+          end)
+
+        assert has_error == true
+      after
+        Process.delete(:scout_apm_request)
+      end
+    end
+  end
+end

--- a/test/scout_apm/logging/log_record_test.exs
+++ b/test/scout_apm/logging/log_record_test.exs
@@ -1,0 +1,148 @@
+defmodule ScoutApm.Logging.LogRecordTest do
+  use ExUnit.Case
+
+  alias ScoutApm.Logging.LogRecord
+
+  describe "new/3" do
+    test "creates a log record with severity and message" do
+      record = LogRecord.new(:info, "Test message")
+
+      assert record.severity == :info
+      assert record.message == "Test message"
+      assert is_integer(record.timestamp_nanos)
+      assert is_integer(record.observed_timestamp_nanos)
+    end
+
+    test "creates a log record with attributes" do
+      record = LogRecord.new(:warning, "Warning", %{"key" => "value"})
+
+      assert record.attributes == %{"key" => "value"}
+    end
+
+    test "truncates long messages" do
+      long_message = String.duplicate("a", 40_000)
+      record = LogRecord.new(:info, long_message)
+
+      assert String.length(record.message) <= 32_768
+      assert String.ends_with?(record.message, "...")
+    end
+  end
+
+  describe "from_logger_event/2" do
+    test "creates from string message event" do
+      event = %{
+        level: :info,
+        msg: {:string, "Hello world"},
+        meta: %{
+          time: System.system_time(:microsecond),
+          file: ~c"test.ex",
+          line: 10
+        }
+      }
+
+      record = LogRecord.from_logger_event(event)
+
+      assert record.severity == :info
+      assert record.message == "Hello world"
+    end
+
+    test "creates from binary string message" do
+      event = %{
+        level: :error,
+        msg: {:string, "Binary message"},
+        meta: %{time: System.system_time(:microsecond)}
+      }
+
+      record = LogRecord.from_logger_event(event)
+
+      assert record.message == "Binary message"
+    end
+
+    test "creates from format message" do
+      event = %{
+        level: :debug,
+        msg: {~c"User ~p logged in", [:john]},
+        meta: %{time: System.system_time(:microsecond)}
+      }
+
+      record = LogRecord.from_logger_event(event)
+
+      assert record.message == "User john logged in"
+    end
+
+    test "includes source location in attributes" do
+      event = %{
+        level: :info,
+        msg: {:string, "test"},
+        meta: %{
+          time: System.system_time(:microsecond),
+          file: ~c"lib/my_app.ex",
+          line: 42,
+          mfa: {MyApp.Module, :function, 2}
+        }
+      }
+
+      record = LogRecord.from_logger_event(event)
+
+      assert record.attributes["code.filepath"] == "lib/my_app.ex"
+      assert record.attributes["code.lineno"] == 42
+      assert record.attributes["code.function"] == "MyApp.Module.function/2"
+    end
+
+    test "includes scout context" do
+      event = %{
+        level: :info,
+        msg: {:string, "test"},
+        meta: %{time: System.system_time(:microsecond)}
+      }
+
+      scout_context = [
+        {"scout.request_id", "req-123"},
+        {"scout.transaction_name", "Controller/Users#show"}
+      ]
+
+      record = LogRecord.from_logger_event(event, scout_context)
+
+      assert record.attributes["scout.request_id"] == "req-123"
+      assert record.attributes["scout.transaction_name"] == "Controller/Users#show"
+    end
+
+    test "includes custom metadata" do
+      event = %{
+        level: :info,
+        msg: {:string, "test"},
+        meta: %{
+          time: System.system_time(:microsecond),
+          user_id: 123,
+          request_id: "abc"
+        }
+      }
+
+      record = LogRecord.from_logger_event(event)
+
+      assert record.attributes["user_id"] == 123
+      assert record.attributes["request_id"] == "abc"
+    end
+
+    test "filters internal metadata" do
+      event = %{
+        level: :info,
+        msg: {:string, "test"},
+        meta: %{
+          time: System.system_time(:microsecond),
+          gl: self(),
+          pid: self(),
+          domain: [:elixir],
+          custom_key: "value"
+        }
+      }
+
+      record = LogRecord.from_logger_event(event)
+
+      refute Map.has_key?(record.attributes, "gl")
+      refute Map.has_key?(record.attributes, "pid")
+      refute Map.has_key?(record.attributes, "domain")
+      assert record.attributes["custom_key"] == "value"
+    end
+  end
+end

--- a/test/scout_apm/logging/otlp/encoder_test.exs
+++ b/test/scout_apm/logging/otlp/encoder_test.exs
@@ -1,0 +1,96 @@
+defmodule ScoutApm.Logging.OTLP.EncoderTest do
+  use ExUnit.Case
+
+  alias ScoutApm.Logging.OTLP.Encoder
+  alias ScoutApm.Logging.LogRecord
+
+  describe "encode/1" do
+    test "encodes a list of log records" do
+      record = LogRecord.new(:info, "Test message", %{"key" => "value"})
+      result = Encoder.encode([record])
+
+      assert is_map(result)
+      assert Map.has_key?(result, "resourceLogs")
+
+      [resource_log] = result["resourceLogs"]
+      assert Map.has_key?(resource_log, "resource")
+      assert Map.has_key?(resource_log, "scopeLogs")
+
+      [scope_log] = resource_log["scopeLogs"]
+      assert Map.has_key?(scope_log, "scope")
+      assert Map.has_key?(scope_log, "logRecords")
+
+      [log_record] = scope_log["logRecords"]
+      assert log_record["severityText"] == "INFO"
+      assert log_record["severityNumber"] == 9
+      assert log_record["body"]["stringValue"] == "Test message"
+    end
+
+    test "encodes empty list" do
+      result = Encoder.encode([])
+
+      [resource_log] = result["resourceLogs"]
+      [scope_log] = resource_log["scopeLogs"]
+      assert scope_log["logRecords"] == []
+    end
+  end
+
+  describe "encode_log_record/1" do
+    test "encodes basic log record" do
+      record = LogRecord.new(:warning, "Warning message")
+      result = Encoder.encode_log_record(record)
+
+      assert result["severityText"] == "WARN"
+      assert result["severityNumber"] == 13
+      assert result["body"]["stringValue"] == "Warning message"
+      assert is_binary(result["timeUnixNano"])
+      assert is_binary(result["observedTimeUnixNano"])
+    end
+
+    test "encodes attributes" do
+      record = LogRecord.new(:info, "Test", %{"string_key" => "value", "int_key" => 42})
+      result = Encoder.encode_log_record(record)
+
+      assert Map.has_key?(result, "attributes")
+      attrs = result["attributes"]
+
+      string_attr = Enum.find(attrs, &(&1["key"] == "string_key"))
+      assert string_attr["value"]["stringValue"] == "value"
+
+      int_attr = Enum.find(attrs, &(&1["key"] == "int_key"))
+      assert int_attr["value"]["intValue"] == "42"
+    end
+
+    test "encodes boolean attributes" do
+      record = LogRecord.new(:info, "Test", %{"bool_key" => true})
+      result = Encoder.encode_log_record(record)
+
+      attrs = result["attributes"]
+      bool_attr = Enum.find(attrs, &(&1["key"] == "bool_key"))
+      assert bool_attr["value"]["boolValue"] == true
+    end
+
+    test "encodes float attributes" do
+      record = LogRecord.new(:info, "Test", %{"float_key" => 3.14})
+      result = Encoder.encode_log_record(record)
+
+      attrs = result["attributes"]
+      float_attr = Enum.find(attrs, &(&1["key"] == "float_key"))
+      assert float_attr["value"]["doubleValue"] == 3.14
+    end
+
+    test "does not include empty attributes" do
+      record = LogRecord.new(:info, "Test", %{})
+      result = Encoder.encode_log_record(record)
+
+      refute Map.has_key?(result, "attributes")
+    end
+
+    test "does not include dropped count when zero" do
+      record = LogRecord.new(:info, "Test")
+      result = Encoder.encode_log_record(record)
+
+      refute Map.has_key?(result, "droppedAttributesCount")
+    end
+  end
+end

--- a/test/scout_apm/logging/otlp/severity_test.exs
+++ b/test/scout_apm/logging/otlp/severity_test.exs
@@ -1,0 +1,100 @@
+defmodule ScoutApm.Logging.OTLP.SeverityTest do
+  use ExUnit.Case
+
+  alias ScoutApm.Logging.OTLP.Severity
+
+  describe "to_number/1" do
+    test "maps debug to 5" do
+      assert Severity.to_number(:debug) == 5
+    end
+
+    test "maps info to 9" do
+      assert Severity.to_number(:info) == 9
+    end
+
+    test "maps notice to 11" do
+      assert Severity.to_number(:notice) == 11
+    end
+
+    test "maps warning to 13" do
+      assert Severity.to_number(:warning) == 13
+    end
+
+    test "maps warn to 13" do
+      assert Severity.to_number(:warn) == 13
+    end
+
+    test "maps error to 17" do
+      assert Severity.to_number(:error) == 17
+    end
+
+    test "maps critical to 21" do
+      assert Severity.to_number(:critical) == 21
+    end
+
+    test "maps alert to 21" do
+      assert Severity.to_number(:alert) == 21
+    end
+
+    test "maps emergency to 21" do
+      assert Severity.to_number(:emergency) == 21
+    end
+
+    test "maps unknown to 0" do
+      assert Severity.to_number(:unknown) == 0
+    end
+  end
+
+  describe "to_text/1" do
+    test "maps debug to DEBUG" do
+      assert Severity.to_text(:debug) == "DEBUG"
+    end
+
+    test "maps info to INFO" do
+      assert Severity.to_text(:info) == "INFO"
+    end
+
+    test "maps warning to WARN" do
+      assert Severity.to_text(:warning) == "WARN"
+    end
+
+    test "maps error to ERROR" do
+      assert Severity.to_text(:error) == "ERROR"
+    end
+
+    test "maps critical to FATAL" do
+      assert Severity.to_text(:critical) == "FATAL"
+    end
+
+    test "maps unknown to UNSPECIFIED" do
+      assert Severity.to_text(:unknown) == "UNSPECIFIED"
+    end
+  end
+
+  describe "meets_level?/2" do
+    test "error meets info level" do
+      assert Severity.meets_level?(:error, :info) == true
+    end
+
+    test "debug does not meet info level" do
+      assert Severity.meets_level?(:debug, :info) == false
+    end
+
+    test "info meets info level" do
+      assert Severity.meets_level?(:info, :info) == true
+    end
+
+    test "warning meets debug level" do
+      assert Severity.meets_level?(:warning, :debug) == true
+    end
+  end
+
+  describe "levels/0" do
+    test "returns all levels in order" do
+      levels = Severity.levels()
+      assert :emergency in levels
+      assert :debug in levels
+      assert length(levels) == 8
+    end
+  end
+end

--- a/test/scout_apm/logging_test.exs
+++ b/test/scout_apm/logging_test.exs
@@ -1,0 +1,56 @@
+defmodule ScoutApm.LoggingTest do
+  use ExUnit.Case
+
+  alias ScoutApm.Logging
+
+  describe "attach/0 and detach/0" do
+    test "attaches and detaches handler" do
+      # Start fresh
+      Logging.detach()
+      refute Logging.attached?()
+
+      # Attach
+      assert Logging.attach() == :ok
+      assert Logging.attached?()
+
+      # Attaching again is idempotent
+      assert Logging.attach() == :ok
+      assert Logging.attached?()
+
+      # Detach
+      assert Logging.detach() == :ok
+      refute Logging.attached?()
+
+      # Detaching again is idempotent
+      assert Logging.detach() == :ok
+      refute Logging.attached?()
+    end
+  end
+
+  describe "enabled?/0" do
+    test "returns false by default" do
+      # Default config has logs_enabled: false
+      assert Logging.enabled?() == false
+    end
+  end
+
+  describe "queue_size/0" do
+    test "returns current queue size" do
+      size = Logging.queue_size()
+      assert is_integer(size)
+      assert size >= 0
+    end
+  end
+
+  describe "flush/0" do
+    test "flushes without error" do
+      assert Logging.flush() == :ok
+    end
+  end
+
+  describe "drain/1" do
+    test "drains without error" do
+      assert Logging.drain(1000) == :ok
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add Erlang logger handler that captures application logs
- OTLP (OpenTelemetry Protocol) encoder for log serialization
- Log exporter that sends logs to Scout's OTLP collector endpoint
- LogService GenServer for batched log delivery
- Context extractor for enriching logs with request metadata
- Severity mapping from Erlang log levels to OTLP severity
- Resource metadata for identifying the application
- README documentation for log management setup

## Test plan

- [ ] Log record creation and serialization tests pass
- [ ] OTLP encoder produces valid protobuf-compatible JSON
- [ ] Severity mapping covers all Erlang log levels
- [ ] Context extractor enriches logs with request/trace IDs
- [ ] Integration: logs appear in Scout's log management UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)