### PR TITLE
Improve database metrics visibility

### DIFF
--- a/lib/scout_apm/commands.ex
+++ b/lib/scout_apm/commands.ex
@@ -304,7 +304,7 @@ defmodule ScoutApm.Command.Batch do
   defp operation(layer), do: "#{layer.type}/#{layer.name}"
 
   defp tag_spans(%Layer{type: "Ecto"} = layer, request_id, span_id) do
-    [
+    base_tags = [
       %Command.TagSpan{
         timestamp: layer.started_at,
         request_id: request_id,
@@ -313,6 +313,38 @@ defmodule ScoutApm.Command.Batch do
         value: layer.desc
       }
     ]
+
+    rows_tag =
+      if layer.db_rows do
+        [
+          %Command.TagSpan{
+            timestamp: layer.started_at,
+            request_id: request_id,
+            span_id: span_id,
+            tag: "db.rows_returned",
+            value: to_string(layer.db_rows)
+          }
+        ]
+      else
+        []
+      end
+
+    op_tag =
+      if layer.db_command do
+        [
+          %Command.TagSpan{
+            timestamp: layer.started_at,
+            request_id: request_id,
+            span_id: span_id,
+            tag: "db.operation",
+            value: layer.db_command
+          }
+        ]
+      else
+        []
+      end
+
+    base_tags ++ rows_tag ++ op_tag
   end
 
   defp tag_spans(%Layer{type: type} = layer, request_id, span_id) when type in ["EEx", "Exs"] do

--- a/lib/scout_apm/instruments/ecto_logger.ex
+++ b/lib/scout_apm/instruments/ecto_logger.ex
@@ -17,11 +17,15 @@ defmodule ScoutApm.Instruments.EctoLogger do
   def log(entry) do
     case query_time_log_entry(entry) do
       {:ok, duration} ->
+        {command, num_rows} = extract_result_info(entry)
+
         ScoutApm.TrackedRequest.track_layer(
           "Ecto",
           query_name_log_entry(entry),
           duration,
-          desc: Map.get(entry, :query)
+          desc: Map.get(entry, :query),
+          db_command: command,
+          db_rows: num_rows
         )
 
       {:error, _} ->
@@ -34,11 +38,15 @@ defmodule ScoutApm.Instruments.EctoLogger do
   def record(value, metadata) do
     case query_time(value, metadata) do
       {:ok, duration} ->
+        {command, num_rows} = extract_result_info(metadata)
+
         ScoutApm.TrackedRequest.track_layer(
           "Ecto",
           query_name(value, metadata),
           duration,
-          desc: Map.get(metadata, :query)
+          desc: Map.get(metadata, :query),
+          db_command: command,
+          db_rows: num_rows
         )
 
       {:error, _} ->
@@ -95,4 +103,20 @@ defmodule ScoutApm.Instruments.EctoLogger do
   def query_time_log_entry(_entry) do
     {:error, :non_integer_query_time}
   end
+
+  @doc false
+  def extract_result_info(%{result: {:ok, result}}) do
+    command = Map.get(result, :command)
+    num_rows = Map.get(result, :num_rows)
+    {normalize_command(command), num_rows}
+  end
+
+  def extract_result_info(_), do: {nil, nil}
+
+  defp normalize_command(:select), do: "Select"
+  defp normalize_command(:insert), do: "Insert"
+  defp normalize_command(:update), do: "Update"
+  defp normalize_command(:delete), do: "Delete"
+  defp normalize_command(cmd) when is_atom(cmd) and not is_nil(cmd), do: cmd |> to_string() |> String.capitalize()
+  defp normalize_command(_), do: nil
 end

--- a/lib/scout_apm/internal/layer.ex
+++ b/lib/scout_apm/internal/layer.ex
@@ -15,7 +15,9 @@ defmodule ScoutApm.Internal.Layer do
           stopped_at: nil | Integer,
           scopable: boolean,
           manual_duration: nil | ScoutApm.Internal.Duration.t(),
-          children: list(%__MODULE__{})
+          children: list(%__MODULE__{}),
+          db_command: nil | String.t(),
+          db_rows: nil | non_neg_integer()
         }
 
   defstruct [
@@ -30,6 +32,10 @@ defmodule ScoutApm.Internal.Layer do
     # If this is set, ignore started_at -> stopped_at valuse when calculating
     # how long this layer ran
     :manual_duration,
+
+    # Database-specific fields for Ecto layers
+    :db_command,
+    :db_rows,
     scopable: true,
     children: []
   ]
@@ -88,6 +94,14 @@ defmodule ScoutApm.Internal.Layer do
     %{layer | manual_duration: duration}
   end
 
+  def update_db_command(layer, db_command) do
+    %{layer | db_command: db_command}
+  end
+
+  def update_db_rows(layer, db_rows) do
+    %{layer | db_rows: db_rows}
+  end
+
   ##################
   #  Update Fields #
   ##################
@@ -103,6 +117,8 @@ defmodule ScoutApm.Internal.Layer do
 
   defp update_field(layer, :desc, value), do: update_desc(layer, value)
   defp update_field(layer, :backtrace, value), do: update_backtrace(layer, value)
+  defp update_field(layer, :db_command, value), do: update_db_command(layer, value)
+  defp update_field(layer, :db_rows, value), do: update_db_rows(layer, value)
 
   #############
   #  Queries  #

--- a/test/scout_apm/instruments/ecto_logger_test.exs
+++ b/test/scout_apm/instruments/ecto_logger_test.exs
@@ -40,6 +40,36 @@ defmodule ScoutApm.Instruments.EctoLoggerTest do
                  Map.get(tag, :tag) == "db.statement"
              end)
     end
+
+    test "includes db.rows_returned and db.operation tags when result is available" do
+      value = %{
+        decode_time: 16000,
+        query_time: 1_192_999,
+        queue_time: 36000
+      }
+
+      metadata = %{
+        source: "users",
+        query: "SELECT u0.\"id\", u0.\"name\", u0.\"age\" FROM \"users\" AS u0",
+        result: {:ok, %{command: :select, num_rows: 5}}
+      }
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+      ScoutApm.Instruments.EctoLogger.record(value, metadata)
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "db.rows_returned" && Map.get(tag, :value) == "5"
+             end)
+
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "db.operation" && Map.get(tag, :value) == "Select"
+             end)
+    end
   end
 
   describe "log/1" do
@@ -73,6 +103,82 @@ defmodule ScoutApm.Instruments.EctoLoggerTest do
                tag &&
                  Map.get(tag, :tag) == "db.statement"
              end)
+    end
+
+    test "includes db.rows_returned and db.operation tags" do
+      entry = %{
+        decode_time: 16000,
+        query_time: 1_192_999,
+        queue_time: 36000,
+        result: {:ok, %{command: :insert, num_rows: 1}},
+        source: "users",
+        query: "INSERT INTO \"users\" (\"name\") VALUES ($1)"
+      }
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+      ScoutApm.Instruments.EctoLogger.log(entry)
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "db.rows_returned" && Map.get(tag, :value) == "1"
+             end)
+
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "db.operation" && Map.get(tag, :value) == "Insert"
+             end)
+    end
+  end
+
+  describe "extract_result_info/1" do
+    alias ScoutApm.Instruments.EctoLogger
+
+    test "extracts command and num_rows from successful result" do
+      metadata = %{result: {:ok, %{command: :select, num_rows: 10}}}
+      assert {"Select", 10} = EctoLogger.extract_result_info(metadata)
+    end
+
+    test "normalizes insert command" do
+      metadata = %{result: {:ok, %{command: :insert, num_rows: 1}}}
+      assert {"Insert", 1} = EctoLogger.extract_result_info(metadata)
+    end
+
+    test "normalizes update command" do
+      metadata = %{result: {:ok, %{command: :update, num_rows: 3}}}
+      assert {"Update", 3} = EctoLogger.extract_result_info(metadata)
+    end
+
+    test "normalizes delete command" do
+      metadata = %{result: {:ok, %{command: :delete, num_rows: 2}}}
+      assert {"Delete", 2} = EctoLogger.extract_result_info(metadata)
+    end
+
+    test "handles unknown commands by capitalizing" do
+      metadata = %{result: {:ok, %{command: :truncate, num_rows: 0}}}
+      assert {"Truncate", 0} = EctoLogger.extract_result_info(metadata)
+    end
+
+    test "returns nil tuple when result is error" do
+      metadata = %{result: {:error, :some_error}}
+      assert {nil, nil} = EctoLogger.extract_result_info(metadata)
+    end
+
+    test "returns nil tuple when result is not present" do
+      metadata = %{source: "users"}
+      assert {nil, nil} = EctoLogger.extract_result_info(metadata)
+    end
+
+    test "handles result without num_rows" do
+      metadata = %{result: {:ok, %{command: :select}}}
+      assert {"Select", nil} = EctoLogger.extract_result_info(metadata)
+    end
+
+    test "handles result without command" do
+      metadata = %{result: {:ok, %{num_rows: 5}}}
+      assert {nil, 5} = EctoLogger.extract_result_info(metadata)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Extract db command (Select/Insert/Update/Delete) and row counts from Ecto telemetry
- Add `db_command` and `db_rows` fields to Layer struct
- Send `db.rows_returned` and `db.operation` span tags to core agent
- Enables richer database metrics in Scout APM (row counts, operation breakdown)

## Test plan

- [ ] Ecto logger extracts command and row count from query results
- [ ] Span tags include `db.rows_returned` and `db.operation`
- [ ] Existing Ecto instrumentation tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)