### PR TITLE
Add external HTTP service instrumentation

### DIFF
--- a/lib/scout_apm/commands.ex
+++ b/lib/scout_apm/commands.ex
@@ -370,6 +370,7 @@ defmodule ScoutApm.Command.Batch do
   defp operation(%Layer{type: "Ecto"}), do: "SQL/Query"
   defp operation(%Layer{type: "EEx"}), do: "Template/Render"
   defp operation(%Layer{type: "Exs"}), do: "Template/Render"
+  defp operation(%Layer{type: "HTTP"} = layer), do: "HTTP/#{layer.name}"
   defp operation(layer), do: "#{layer.type}/#{layer.name}"
 
   defp tag_spans(%Layer{type: "Ecto"} = layer, request_id, span_id) do
@@ -426,6 +427,49 @@ defmodule ScoutApm.Command.Batch do
         value: layer.name
       }
     ]
+  end
+
+  defp tag_spans(%Layer{type: "HTTP"} = layer, request_id, span_id) do
+    # Send "url" tag for core agent domain extraction (it looks for "uri" then "url")
+    # Keep "http.url" for any downstream consumers that may depend on it
+    url_tags =
+      if layer.http_url do
+        [
+          %Command.TagSpan{
+            timestamp: layer.started_at,
+            request_id: request_id,
+            span_id: span_id,
+            tag: "url",
+            value: layer.http_url
+          },
+          %Command.TagSpan{
+            timestamp: layer.started_at,
+            request_id: request_id,
+            span_id: span_id,
+            tag: "http.url",
+            value: layer.http_url
+          }
+        ]
+      else
+        []
+      end
+
+    status_tag =
+      if layer.http_status_code do
+        [
+          %Command.TagSpan{
+            timestamp: layer.started_at,
+            request_id: request_id,
+            span_id: span_id,
+            tag: "http.status_code",
+            value: to_string(layer.http_status_code)
+          }
+        ]
+      else
+        []
+      end
+
+    url_tags ++ status_tag
   end
 
   defp tag_spans(_layer, _request_id, _span_id), do: []

--- a/lib/scout_apm/instruments/finch_telemetry.ex
+++ b/lib/scout_apm/instruments/finch_telemetry.ex
@@ -1,0 +1,167 @@
+if Code.ensure_loaded?(Telemetry) || Code.ensure_loaded?(:telemetry) do
+  defmodule ScoutApm.Instruments.FinchTelemetry do
+    @moduledoc """
+    Telemetry handler for Finch HTTP client instrumentation.
+
+    Attaches to Finch telemetry events to track external HTTP requests:
+    - HTTP requests appear as "HTTP" type layers (External Services)
+    - Tracks URL, HTTP method, and response status code
+
+    ## Usage
+
+    In your application's `start/2` function:
+
+        def start(_type, _args) do
+          ScoutApm.Instruments.FinchTelemetry.attach()
+          # ... rest of supervision tree
+        end
+
+    This will automatically instrument all Finch HTTP requests in your application,
+    including those made through libraries built on Finch (like Req).
+
+    ## What's Tracked
+
+    - **Operation**: `HTTP/{method}` (e.g., "HTTP/GET", "HTTP/POST")
+    - **URL**: The full URL of the request (sanitized)
+    - **Status Code**: The HTTP response status code
+
+    ## Configuration
+
+    Requests to Scout APM's own endpoints are automatically excluded from tracking.
+    """
+
+    alias ScoutApm.TrackedRequest
+    alias ScoutApm.Internal.Duration
+
+    require Logger
+
+    @events [
+      [:finch, :request, :stop],
+      [:finch, :request, :exception]
+    ]
+
+    # Scout APM hosts that should not be instrumented
+    @scout_hosts [
+      "errors.scoutapm.com",
+      "apm.scoutapp.com",
+      "checkin.scoutapm.com",
+      "otlp.scoutotel.com"
+    ]
+
+    @doc """
+    Attaches telemetry handlers for Finch HTTP request events.
+
+    Call this once during application startup.
+    """
+    def attach do
+      :telemetry.attach_many(
+        "scout-apm-finch-telemetry",
+        @events,
+        &__MODULE__.handle_event/4,
+        nil
+      )
+    end
+
+    @doc """
+    Detaches the telemetry handlers. Useful for testing.
+    """
+    def detach do
+      :telemetry.detach("scout-apm-finch-telemetry")
+    end
+
+    # Request completed successfully
+    def handle_event(
+          [:finch, :request, :stop],
+          %{duration: duration} = _measurements,
+          %{request: request, result: result} = _metadata,
+          _config
+        ) do
+      url = build_url(request)
+
+      if should_instrument?(url) do
+        method = normalize_method(request)
+        status_code = extract_status_code(result)
+
+        duration_struct =
+          Duration.new(System.convert_time_unit(duration, :native, :microsecond), :microseconds)
+
+        TrackedRequest.track_layer(
+          "HTTP",
+          method,
+          duration_struct,
+          http_method: method,
+          http_url: url,
+          http_status_code: status_code
+        )
+      end
+
+      :ok
+    end
+
+    # Request failed with exception
+    def handle_event(
+          [:finch, :request, :exception],
+          %{duration: duration} = _measurements,
+          %{request: request, kind: _kind, reason: _reason} = _metadata,
+          _config
+        ) do
+      url = build_url(request)
+
+      if should_instrument?(url) do
+        method = normalize_method(request)
+
+        duration_struct =
+          Duration.new(System.convert_time_unit(duration, :native, :microsecond), :microseconds)
+
+        TrackedRequest.track_layer(
+          "HTTP",
+          method,
+          duration_struct,
+          http_method: method,
+          http_url: url,
+          http_status_code: nil
+        )
+      end
+
+      :ok
+    end
+
+    # Catch-all for unhandled events
+    def handle_event(_event, _measurements, _metadata, _config), do: :ok
+
+    # Build URL from Finch request struct
+    defp build_url(%{scheme: scheme, host: host, port: port, path: path}) do
+      port_str = format_port(scheme, port)
+      path_str = path || "/"
+      "#{scheme}://#{host}#{port_str}#{path_str}"
+    end
+
+    defp build_url(_request), do: "Unknown"
+
+    # Format port, omitting default ports
+    defp format_port(:https, 443), do: ""
+    defp format_port(:http, 80), do: ""
+    defp format_port("https", 443), do: ""
+    defp format_port("http", 80), do: ""
+    defp format_port(_scheme, port), do: ":#{port}"
+
+    # Normalize HTTP method to uppercase string
+    defp normalize_method(%{method: method}) when is_binary(method), do: String.upcase(method)
+
+    defp normalize_method(%{method: method}) when is_atom(method),
+      do: method |> Atom.to_string() |> String.upcase()
+
+    defp normalize_method(_), do: "UNKNOWN"
+
+    # Extract status code from result
+    defp extract_status_code({:ok, %{status: status}}), do: status
+    defp extract_status_code(_), do: nil
+
+    # Check if this URL should be instrumented (exclude Scout APM hosts)
+    defp should_instrument?(url) when is_binary(url) do
+      not Enum.any?(@scout_hosts, fn host -> String.contains?(url, host) end)
+    end
+
+    defp should_instrument?(_), do: true
+  end
+end

--- a/lib/scout_apm/instruments/tesla_telemetry.ex
+++ b/lib/scout_apm/instruments/tesla_telemetry.ex
@@ -1,0 +1,213 @@
+if Code.ensure_loaded?(Telemetry) || Code.ensure_loaded?(:telemetry) do
+  defmodule ScoutApm.Instruments.TeslaTelemetry do
+    @moduledoc """
+    Telemetry handler for Tesla HTTP client instrumentation.
+
+    Attaches to Tesla telemetry events to track external HTTP requests:
+    - HTTP requests appear as "HTTP" type layers (External Services)
+    - Tracks URL, HTTP method, and response status code
+
+    ## Prerequisites
+
+    Your Tesla client must include the Telemetry middleware. Add it to your client:
+
+        defmodule MyApp.ApiClient do
+          use Tesla
+
+          plug Tesla.Middleware.Telemetry
+          plug Tesla.Middleware.BaseUrl, "https://api.example.com"
+          # ... other middleware
+        end
+
+    **Important:** Place `Tesla.Middleware.Telemetry` as close as possible to the end
+    of the middleware stack to ensure accurate timing measurements.
+
+    ## Usage
+
+    In your application's `start/2` function:
+
+        def start(_type, _args) do
+          ScoutApm.Instruments.TeslaTelemetry.attach()
+          # ... rest of supervision tree
+        end
+
+    ## What's Tracked
+
+    - **Operation**: `HTTP/{method}` (e.g., "HTTP/GET", "HTTP/POST")
+    - **URL**: The full URL of the request (sanitized)
+    - **Status Code**: The HTTP response status code
+
+    ## Configuration
+
+    Requests to Scout APM's own endpoints are automatically excluded from tracking.
+    """
+
+    alias ScoutApm.TrackedRequest
+    alias ScoutApm.Internal.Duration
+
+    require Logger
+
+    @events [
+      [:tesla, :request, :stop],
+      [:tesla, :request, :exception]
+    ]
+
+    # Scout APM hosts that should not be instrumented
+    @scout_hosts [
+      "errors.scoutapm.com",
+      "apm.scoutapp.com",
+      "checkin.scoutapm.com",
+      "otlp.scoutotel.com"
+    ]
+
+    @doc """
+    Attaches telemetry handlers for Tesla HTTP request events.
+
+    Call this once during application startup.
+    """
+    def attach do
+      :telemetry.attach_many(
+        "scout-apm-tesla-telemetry",
+        @events,
+        &__MODULE__.handle_event/4,
+        nil
+      )
+    end
+
+    @doc """
+    Detaches the telemetry handlers. Useful for testing.
+    """
+    def detach do
+      :telemetry.detach("scout-apm-tesla-telemetry")
+    end
+
+    # Request completed with error in metadata — must come before success clause
+    # since %{env: env} would also match maps containing an :error key
+    def handle_event(
+          [:tesla, :request, :stop],
+          %{duration: duration} = _measurements,
+          %{env: env, error: _error} = _metadata,
+          _config
+        ) do
+      url = build_url(env)
+
+      if should_instrument?(url) do
+        method = normalize_method(env)
+
+        duration_struct =
+          Duration.new(System.convert_time_unit(duration, :native, :microsecond), :microseconds)
+
+        TrackedRequest.track_layer(
+          "HTTP",
+          method,
+          duration_struct,
+          http_method: method,
+          http_url: url,
+          http_status_code: nil
+        )
+      end
+
+      :ok
+    end
+
+    # Request completed successfully
+    def handle_event(
+          [:tesla, :request, :stop],
+          %{duration: duration} = _measurements,
+          %{env: env} = _metadata,
+          _config
+        ) do
+      url = build_url(env)
+
+      if should_instrument?(url) do
+        method = normalize_method(env)
+        status_code = extract_status_code(env)
+
+        duration_struct =
+          Duration.new(System.convert_time_unit(duration, :native, :microsecond), :microseconds)
+
+        TrackedRequest.track_layer(
+          "HTTP",
+          method,
+          duration_struct,
+          http_method: method,
+          http_url: url,
+          http_status_code: status_code
+        )
+      end
+
+      :ok
+    end
+
+    # Request failed with exception
+    def handle_event(
+          [:tesla, :request, :exception],
+          %{duration: duration} = _measurements,
+          %{env: env} = _metadata,
+          _config
+        ) do
+      url = build_url(env)
+
+      if should_instrument?(url) do
+        method = normalize_method(env)
+
+        duration_struct =
+          Duration.new(System.convert_time_unit(duration, :native, :microsecond), :microseconds)
+
+        TrackedRequest.track_layer(
+          "HTTP",
+          method,
+          duration_struct,
+          http_method: method,
+          http_url: url,
+          http_status_code: nil
+        )
+      end
+
+      :ok
+    end
+
+    # Catch-all for unhandled events
+    def handle_event(_event, _measurements, _metadata, _config), do: :ok
+
+    # Build URL from Tesla.Env struct, stripping query strings to avoid leaking sensitive data
+    defp build_url(%{url: url}) when is_binary(url) do
+      case URI.parse(url) do
+        %URI{scheme: scheme, host: host, port: port, path: path}
+        when is_binary(scheme) and is_binary(host) ->
+          port_str = format_port(scheme, port)
+          path_str = path || "/"
+          "#{scheme}://#{host}#{port_str}#{path_str}"
+
+        _ ->
+          url
+      end
+    end
+
+    defp build_url(_env), do: "Unknown"
+
+    # Format port, omitting default ports
+    defp format_port("https", 443), do: ""
+    defp format_port("http", 80), do: ""
+    defp format_port(_, nil), do: ""
+    defp format_port(_, port), do: ":#{port}"
+
+    # Normalize HTTP method to uppercase string
+    defp normalize_method(%{method: method}) when is_atom(method),
+      do: method |> Atom.to_string() |> String.upcase()
+
+    defp normalize_method(%{method: method}) when is_binary(method), do: String.upcase(method)
+    defp normalize_method(_), do: "UNKNOWN"
+
+    # Extract status code from Tesla.Env
+    defp extract_status_code(%{status: status}) when is_integer(status), do: status
+    defp extract_status_code(_), do: nil
+
+    # Check if this URL should be instrumented (exclude Scout APM hosts)
+    defp should_instrument?(url) when is_binary(url) do
+      not Enum.any?(@scout_hosts, fn host -> String.contains?(url, host) end)
+    end
+
+    defp should_instrument?(_), do: true
+  end
+end

--- a/lib/scout_apm/internal/layer.ex
+++ b/lib/scout_apm/internal/layer.ex
@@ -17,7 +17,10 @@ defmodule ScoutApm.Internal.Layer do
           manual_duration: nil | ScoutApm.Internal.Duration.t(),
           children: list(%__MODULE__{}),
           db_command: nil | String.t(),
-          db_rows: nil | non_neg_integer()
+          db_rows: nil | non_neg_integer(),
+          http_method: nil | String.t(),
+          http_url: nil | String.t(),
+          http_status_code: nil | non_neg_integer()
         }
 
   defstruct [
@@ -36,6 +39,11 @@ defmodule ScoutApm.Internal.Layer do
     # Database-specific fields for Ecto layers
     :db_command,
     :db_rows,
+
+    # HTTP-specific fields for External Service layers
+    :http_method,
+    :http_url,
+    :http_status_code,
     scopable: true,
     children: []
   ]
@@ -102,6 +110,18 @@ defmodule ScoutApm.Internal.Layer do
     %{layer | db_rows: db_rows}
   end
 
+  def update_http_method(layer, http_method) do
+    %{layer | http_method: http_method}
+  end
+
+  def update_http_url(layer, http_url) do
+    %{layer | http_url: http_url}
+  end
+
+  def update_http_status_code(layer, http_status_code) do
+    %{layer | http_status_code: http_status_code}
+  end
+
   ##################
   #  Update Fields #
   ##################
@@ -119,6 +139,9 @@ defmodule ScoutApm.Internal.Layer do
   defp update_field(layer, :backtrace, value), do: update_backtrace(layer, value)
   defp update_field(layer, :db_command, value), do: update_db_command(layer, value)
   defp update_field(layer, :db_rows, value), do: update_db_rows(layer, value)
+  defp update_field(layer, :http_method, value), do: update_http_method(layer, value)
+  defp update_field(layer, :http_url, value), do: update_http_url(layer, value)
+  defp update_field(layer, :http_status_code, value), do: update_http_status_code(layer, value)
 
   #############
   #  Queries  #

--- a/test/scout_apm/instruments/finch_telemetry_test.exs
+++ b/test/scout_apm/instruments/finch_telemetry_test.exs
@@ -1,0 +1,274 @@
+defmodule ScoutApm.Instruments.FinchTelemetryTest do
+  use ExUnit.Case
+
+  alias ScoutApm.Instruments.FinchTelemetry
+
+  setup do
+    ScoutApm.TestCollector.clear_messages()
+    :ok
+  end
+
+  describe "attach/0" do
+    test "attaches telemetry handlers successfully" do
+      # Detach first in case already attached
+      try do
+        FinchTelemetry.detach()
+      rescue
+        _ -> :ok
+      end
+
+      assert :ok = FinchTelemetry.attach()
+
+      # Clean up
+      FinchTelemetry.detach()
+    end
+  end
+
+  describe "handle_event/4 for request stop" do
+    test "records HTTP layer for successful request" do
+      request = %{
+        scheme: :https,
+        host: "api.example.com",
+        port: 443,
+        path: "/users",
+        method: "GET"
+      }
+
+      # 1ms in native time
+      measurements = %{duration: 1_000_000}
+      metadata = %{request: request, result: {:ok, %{status: 200}}}
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+      FinchTelemetry.handle_event([:finch, :request, :stop], measurements, metadata, nil)
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      # Verify HTTP operation span was created
+      assert Enum.any?(commands, fn command ->
+               span = Map.get(command, :StartSpan)
+               span && Map.get(span, :operation) == "HTTP/GET"
+             end)
+
+      # Verify "url" tag for core agent domain extraction
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+
+               tag && Map.get(tag, :tag) == "url" &&
+                 Map.get(tag, :value) == "https://api.example.com/users"
+             end)
+
+      # Verify "http.url" tag for compatibility
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+
+               tag && Map.get(tag, :tag) == "http.url" &&
+                 Map.get(tag, :value) == "https://api.example.com/users"
+             end)
+
+      # Verify http.status_code tag was created
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "http.status_code" && Map.get(tag, :value) == "200"
+             end)
+    end
+
+    test "records HTTP layer with POST method" do
+      request = %{
+        scheme: :https,
+        host: "api.example.com",
+        port: 443,
+        path: "/users",
+        method: :post
+      }
+
+      measurements = %{duration: 2_000_000}
+      metadata = %{request: request, result: {:ok, %{status: 201}}}
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+      FinchTelemetry.handle_event([:finch, :request, :stop], measurements, metadata, nil)
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      assert Enum.any?(commands, fn command ->
+               span = Map.get(command, :StartSpan)
+               span && Map.get(span, :operation) == "HTTP/POST"
+             end)
+
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "http.status_code" && Map.get(tag, :value) == "201"
+             end)
+    end
+
+    test "omits default ports in URL" do
+      request_https = %{
+        scheme: :https,
+        host: "api.example.com",
+        port: 443,
+        path: "/test",
+        method: "GET"
+      }
+
+      request_http = %{
+        scheme: :http,
+        host: "api.example.com",
+        port: 80,
+        path: "/test",
+        method: "GET"
+      }
+
+      request_custom = %{
+        scheme: :https,
+        host: "api.example.com",
+        port: 8443,
+        path: "/test",
+        method: "GET"
+      }
+
+      measurements = %{duration: 1_000_000}
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+
+      FinchTelemetry.handle_event(
+        [:finch, :request, :stop],
+        measurements,
+        %{request: request_https, result: {:ok, %{status: 200}}},
+        nil
+      )
+
+      FinchTelemetry.handle_event(
+        [:finch, :request, :stop],
+        measurements,
+        %{request: request_http, result: {:ok, %{status: 200}}},
+        nil
+      )
+
+      FinchTelemetry.handle_event(
+        [:finch, :request, :stop],
+        measurements,
+        %{request: request_custom, result: {:ok, %{status: 200}}},
+        nil
+      )
+
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      tag_values = fn tag_name ->
+        commands
+        |> Enum.filter(fn cmd -> Map.has_key?(cmd, :TagSpan) end)
+        |> Enum.map(fn %{TagSpan: tag} -> tag end)
+        |> Enum.filter(fn tag -> tag.tag == tag_name end)
+        |> Enum.map(fn tag -> tag.value end)
+      end
+
+      # Both "url" and "http.url" tags should have the same values
+      for tag_name <- ["url", "http.url"] do
+        urls = tag_values.(tag_name)
+        assert "https://api.example.com/test" in urls
+        assert "http://api.example.com/test" in urls
+        assert "https://api.example.com:8443/test" in urls
+      end
+    end
+
+    test "skips Scout APM hosts" do
+      scout_hosts = [
+        %{
+          scheme: :https,
+          host: "errors.scoutapm.com",
+          port: 443,
+          path: "/errors",
+          method: "POST"
+        },
+        %{scheme: :https, host: "apm.scoutapp.com", port: 443, path: "/checkin", method: "POST"},
+        %{scheme: :https, host: "checkin.scoutapm.com", port: 443, path: "/", method: "POST"},
+        %{
+          scheme: :https,
+          host: "otlp.scoutotel.com",
+          port: 4318,
+          path: "/v1/logs",
+          method: "POST"
+        }
+      ]
+
+      measurements = %{duration: 1_000_000}
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+
+      for request <- scout_hosts do
+        FinchTelemetry.handle_event(
+          [:finch, :request, :stop],
+          measurements,
+          %{request: request, result: {:ok, %{status: 200}}},
+          nil
+        )
+      end
+
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      # Should only have the Controller span, no HTTP spans for Scout hosts
+      http_spans =
+        Enum.filter(commands, fn cmd ->
+          case Map.get(cmd, :StartSpan) do
+            %{operation: "HTTP/" <> _} -> true
+            _ -> false
+          end
+        end)
+
+      assert Enum.empty?(http_spans)
+    end
+  end
+
+  describe "handle_event/4 for request exception" do
+    test "records HTTP layer for failed request" do
+      request = %{
+        scheme: :https,
+        host: "api.example.com",
+        port: 443,
+        path: "/users",
+        method: "GET"
+      }
+
+      measurements = %{duration: 5_000_000}
+
+      metadata = %{
+        request: request,
+        kind: :error,
+        reason: %RuntimeError{message: "Connection refused"}
+      }
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+      FinchTelemetry.handle_event([:finch, :request, :exception], measurements, metadata, nil)
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      # Verify HTTP operation span was created
+      assert Enum.any?(commands, fn command ->
+               span = Map.get(command, :StartSpan)
+               span && Map.get(span, :operation) == "HTTP/GET"
+             end)
+
+      # Verify both url tags were created
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "url"
+             end)
+
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "http.url"
+             end)
+
+      # No status code tag for exceptions
+      refute Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "http.status_code"
+             end)
+    end
+  end
+end

--- a/test/scout_apm/instruments/tesla_telemetry_test.exs
+++ b/test/scout_apm/instruments/tesla_telemetry_test.exs
@@ -1,0 +1,275 @@
+defmodule ScoutApm.Instruments.TeslaTelemetryTest do
+  use ExUnit.Case
+
+  alias ScoutApm.Instruments.TeslaTelemetry
+
+  setup do
+    ScoutApm.TestCollector.clear_messages()
+    :ok
+  end
+
+  describe "attach/0" do
+    test "attaches telemetry handlers successfully" do
+      # Detach first in case already attached
+      try do
+        TeslaTelemetry.detach()
+      rescue
+        _ -> :ok
+      end
+
+      assert :ok = TeslaTelemetry.attach()
+
+      # Clean up
+      TeslaTelemetry.detach()
+    end
+  end
+
+  describe "handle_event/4 for request stop" do
+    test "records HTTP layer for successful request" do
+      env = %{
+        url: "https://api.example.com/users",
+        method: :get,
+        status: 200
+      }
+
+      # 1ms in native time
+      measurements = %{duration: 1_000_000}
+      metadata = %{env: env}
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+      TeslaTelemetry.handle_event([:tesla, :request, :stop], measurements, metadata, nil)
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      # Verify HTTP operation span was created
+      assert Enum.any?(commands, fn command ->
+               span = Map.get(command, :StartSpan)
+               span && Map.get(span, :operation) == "HTTP/GET"
+             end)
+
+      # Verify "url" tag for core agent domain extraction
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+
+               tag && Map.get(tag, :tag) == "url" &&
+                 Map.get(tag, :value) == "https://api.example.com/users"
+             end)
+
+      # Verify "http.url" tag for compatibility
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+
+               tag && Map.get(tag, :tag) == "http.url" &&
+                 Map.get(tag, :value) == "https://api.example.com/users"
+             end)
+
+      # Verify http.status_code tag was created
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "http.status_code" && Map.get(tag, :value) == "200"
+             end)
+    end
+
+    test "records HTTP layer with POST method" do
+      env = %{
+        url: "https://api.example.com/users",
+        method: :post,
+        status: 201
+      }
+
+      measurements = %{duration: 2_000_000}
+      metadata = %{env: env}
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+      TeslaTelemetry.handle_event([:tesla, :request, :stop], measurements, metadata, nil)
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      assert Enum.any?(commands, fn command ->
+               span = Map.get(command, :StartSpan)
+               span && Map.get(span, :operation) == "HTTP/POST"
+             end)
+
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "http.status_code" && Map.get(tag, :value) == "201"
+             end)
+    end
+
+    test "handles string method values" do
+      env = %{
+        url: "https://api.example.com/users",
+        method: "PUT",
+        status: 200
+      }
+
+      measurements = %{duration: 1_000_000}
+      metadata = %{env: env}
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+      TeslaTelemetry.handle_event([:tesla, :request, :stop], measurements, metadata, nil)
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      assert Enum.any?(commands, fn command ->
+               span = Map.get(command, :StartSpan)
+               span && Map.get(span, :operation) == "HTTP/PUT"
+             end)
+    end
+
+    test "strips query strings from URLs" do
+      env = %{
+        url: "https://api.example.com/users?api_key=secret123&page=1",
+        method: :get,
+        status: 200
+      }
+
+      measurements = %{duration: 1_000_000}
+      metadata = %{env: env}
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+      TeslaTelemetry.handle_event([:tesla, :request, :stop], measurements, metadata, nil)
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      # URL should have query string stripped
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+
+               tag && Map.get(tag, :tag) == "url" &&
+                 Map.get(tag, :value) == "https://api.example.com/users"
+             end)
+
+      # Should NOT contain query parameters
+      refute Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+
+               tag && Map.get(tag, :tag) == "url" &&
+                 String.contains?(Map.get(tag, :value, ""), "secret123")
+             end)
+    end
+
+    test "skips Scout APM hosts" do
+      scout_envs = [
+        %{url: "https://errors.scoutapm.com/errors", method: :post, status: 200},
+        %{url: "https://apm.scoutapp.com/checkin", method: :post, status: 200},
+        %{url: "https://checkin.scoutapm.com/", method: :post, status: 200},
+        %{url: "https://otlp.scoutotel.com:4318/v1/logs", method: :post, status: 200}
+      ]
+
+      measurements = %{duration: 1_000_000}
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+
+      for env <- scout_envs do
+        TeslaTelemetry.handle_event([:tesla, :request, :stop], measurements, %{env: env}, nil)
+      end
+
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      # Should only have the Controller span, no HTTP spans for Scout hosts
+      http_spans =
+        Enum.filter(commands, fn cmd ->
+          case Map.get(cmd, :StartSpan) do
+            %{operation: "HTTP/" <> _} -> true
+            _ -> false
+          end
+        end)
+
+      assert Enum.empty?(http_spans)
+    end
+
+    test "handles request with error in metadata" do
+      env = %{
+        url: "https://api.example.com/users",
+        method: :get,
+        status: nil
+      }
+
+      measurements = %{duration: 5_000_000}
+      metadata = %{env: env, error: {:error, :econnrefused}}
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+      TeslaTelemetry.handle_event([:tesla, :request, :stop], measurements, metadata, nil)
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      # Verify HTTP operation span was created
+      assert Enum.any?(commands, fn command ->
+               span = Map.get(command, :StartSpan)
+               span && Map.get(span, :operation) == "HTTP/GET"
+             end)
+
+      # Verify both url tags were created
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "url"
+             end)
+
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "http.url"
+             end)
+
+      # No status code tag for errors
+      refute Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "http.status_code"
+             end)
+    end
+  end
+
+  describe "handle_event/4 for request exception" do
+    test "records HTTP layer for failed request" do
+      env = %{
+        url: "https://api.example.com/users",
+        method: :get
+      }
+
+      measurements = %{duration: 5_000_000}
+
+      metadata = %{
+        env: env,
+        kind: :error,
+        reason: %RuntimeError{message: "Connection refused"},
+        stacktrace: []
+      }
+
+      ScoutApm.TrackedRequest.start_layer("Controller", "test")
+      TeslaTelemetry.handle_event([:tesla, :request, :exception], measurements, metadata, nil)
+      ScoutApm.TrackedRequest.stop_layer()
+
+      [%{BatchCommand: %{commands: commands}}] = ScoutApm.TestCollector.messages()
+
+      # Verify HTTP operation span was created
+      assert Enum.any?(commands, fn command ->
+               span = Map.get(command, :StartSpan)
+               span && Map.get(span, :operation) == "HTTP/GET"
+             end)
+
+      # Verify both url tags were created
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "url"
+             end)
+
+      assert Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "http.url"
+             end)
+
+      # No status code tag for exceptions
+      refute Enum.any?(commands, fn command ->
+               tag = Map.get(command, :TagSpan)
+               tag && Map.get(tag, :tag) == "http.status_code"
+             end)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add Finch telemetry handler for tracking outbound HTTP requests (covers Req, which uses Finch)
- Add Tesla telemetry handler for tracking Tesla HTTP client requests
- HTTP layers appear as `HTTP/{METHOD}` operations in Scout APM's External Services view
- Send both `url` and `http.url` span tags (core agent reads `url` for domain extraction)
- Strip query strings from Tesla URLs to prevent sensitive data exposure
- Exclude Scout APM's own endpoints from instrumentation
- Add `http_method`, `http_url`, `http_status_code` fields to Layer struct

## Test plan

- [ ] Finch telemetry captures GET/POST requests with correct operation names
- [ ] Tesla telemetry captures requests with correct operation names
- [ ] Default ports (80/443) are omitted from URLs
- [ ] Query strings are stripped from Tesla URLs
- [ ] Scout APM hosts are excluded from tracking
- [ ] Exception/error cases record layers without status codes
- [ ] `url` tag is present for core agent domain extraction
- [ ] All 183 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)