### PR TITLE
Version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,7 @@ jobs:
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           MIX_VERSION=$(grep 'version:' mix.exs | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          echo "Tag version: $TAG_VERSION"
-          echo "Mix version: $MIX_VERSION"
+          echo "Tag version: $TAG_VERSION" echo "Mix version: $MIX_VERSION"
           if [ "$TAG_VERSION" != "$MIX_VERSION" ]; then
             echo "::error::Tag version ($TAG_VERSION) does not match mix.exs version ($MIX_VERSION)"
             exit 1
@@ -80,22 +79,3 @@ jobs:
         run: mix hex.publish --yes
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          VERSION="${TAG#v}"
-
-          # Detect pre-release from version string (rc, alpha, beta, dev)
-          if echo "$VERSION" | grep -qE '[-](rc|alpha|beta|dev)'; then
-            PRERELEASE="--prerelease"
-          else
-            PRERELEASE=""
-          fi
-
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --generate-notes \
-            $PRERELEASE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   * Metadata Capture — Improved application metadata reporting including Elixir version, loaded libraries, hostname, and git SHA.
 
 * Enhancements
-  * Update Core Agent to v1.5.0 (from v1.2.6)
+  * Update Core Agent to v1.5.1 (from v1.2.6)
   * Update telemetry dependency to `~> 1.0` (from `~> 0.3.0 or ~> 0.4.0`)
   * Phoenix, phoenix_html, and phoenix_live_view are now optional dependencies (enables compile-time HEEx instrumentation)
   * Ecto logger extracts SQL command type and row counts from query results

--- a/lib/scout_apm/core.ex
+++ b/lib/scout_apm/core.ex
@@ -42,7 +42,7 @@ defmodule ScoutApm.Core do
     triple = "#{architecture()}-#{platform()}"
     # For Apple Silicon (M1/M2/M3), use x86_64 binary via Rosetta 2
     # since there's no native ARM build of the Core Agent.
-    # See https://github.com/scoutapp/scout_apm_python/issues/683
+    # No native ARM build of the Core Agent exists yet.
     apple_darwin_aarch64_override(triple)
   end
 

--- a/lib/scout_apm/core/agent_manager.ex
+++ b/lib/scout_apm/core/agent_manager.ex
@@ -4,10 +4,10 @@ defmodule ScoutApm.Core.AgentManager do
   alias ScoutApm.Core.Manifest
   @behaviour ScoutApm.Collector
 
-  # TCP recv/send timeout in milliseconds (matches Python agent's 3s)
+  # TCP recv/send timeout in milliseconds
   @tcp_timeout 3_000
 
-  # Maximum queued messages before dropping (Python agent uses 500)
+  # Maximum queued messages before dropping
   @max_queue_size 500
 
   # Consecutive errors before attempting reconnect

--- a/lib/scout_apm/error/error_data.ex
+++ b/lib/scout_apm/error/error_data.ex
@@ -1,7 +1,6 @@
 defmodule ScoutApm.Error.ErrorData do
   @moduledoc """
   Internal representation of an error to be sent to Scout APM.
-  Matches the Python agent's error data structure for backend compatibility.
   """
 
   alias ScoutApm.Error.ParameterFilter
@@ -167,7 +166,7 @@ defmodule ScoutApm.Error.ErrorData do
     scm_subdirectory = ScoutApm.Config.find(:scm_subdirectory) || ""
 
     stacktrace
-    # Limit to 50 frames like Python
+    # Limit to 50 frames
     |> Enum.take(50)
     |> Enum.map(fn
       {mod, fun, arity, location} when is_integer(arity) ->

--- a/lib/scout_apm/error/parameter_filter.ex
+++ b/lib/scout_apm/error/parameter_filter.ex
@@ -1,7 +1,6 @@
 defmodule ScoutApm.Error.ParameterFilter do
   @moduledoc """
   Filters sensitive parameters from request data before sending to Scout APM.
-  Matches the Python agent's FILTER_PARAMETERS list.
   """
 
   @default_filter_parameters MapSet.new([

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ScoutApm.Mixfile do
   def project do
     [
       app: :scout_apm,
-      version: "2.0.0-rc.1",
+      version: "2.0.0",
       elixir: "~> 1.14",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
@@ -33,7 +33,7 @@ defmodule ScoutApm.Mixfile do
       # We only use `request/5` from hackney, which hasn't changed in the 1.0 line.
       {:hackney, "~> 1.0"},
       {:approximate_histogram, "~> 0.1.1"},
-      {:telemetry, "~> 1.0", optional: true},
+      {:telemetry, "~> 1.0"},
 
       # Optional Phoenix instrumentation dependencies
       {:phoenix, "~> 1.6", optional: true},
@@ -61,7 +61,7 @@ defmodule ScoutApm.Mixfile do
       licenses: ["Scout Software Agent License"],
       links: %{
         "GitHub" => "https://github.com/scoutapp/scout_apm_elixir",
-        "Docs" => "http://docs.scoutapm.com/#elixir-agent"
+        "Docs" => "http://docs.scoutapm.com/elixir"
       }
     ]
   end


### PR DESCRIPTION
- Docstring updates remove Python references
- Make telemetry a hard dependency; not worth installing without it
- Update docs link for Hex