### PR TITLE
Relicense under MIT, aligning with the Ruby and Python agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # 2.1.0
 
+* License
+  * The agent is now licensed under the MIT License, aligning with the Scout Ruby and Python agents. It was previously under the proprietary "Scout Software Agent License".
+
 * Enhancements
   * Allow hackney 4.x: the hackney dependency constraint is now `~> 1.0 or ~> 4.0 and >= 4.0.1` (previously `~> 1.0`). This unblocks resolution alongside packages that require hackney 4.x (e.g. `ex_aws` 2.7+) and allows upgrading past the hackney 1.25.0 CVEs (CVE-2026-47069, CVE-2026-47071, CVE-2026-47075, CVE-2026-47076), whose fixes ship only in hackney 4.0.1+. The agent remains fully compatible with hackney 1.x — existing lock files are unaffected. Note: hackney 4.x itself requires Erlang/OTP 27+; on older OTP releases, keep hackney 1.x by adding `{:hackney, "~> 1.24"}` to your application's deps. ([#141](https://github.com/scoutapp/scout_apm_elixir/issues/141))
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,27 +1,21 @@
-# Scout Software Agent License 
+The MIT License (MIT)
 
-Subject to and conditioned upon your continued compliance with the terms and conditions of this license, Zimuth, Inc. grants you a non-exclusive, non-sublicensable and non-transferable, limited license to install, use and run one copy of this software on each of your and your affiliate’s computers.  This license also grants you the limited right to distribute verbatim copies of this software and documentation to third parties provided the software and documentation will (a) remain the exclusive property of Zimuth; (b) be subject to the terms and conditions of this license; and (c) include a complete and unaltered copy of this license and all other copyright or other intellectual property rights notices contained in the original.
+Copyright (c) 2017-2026 Zimuth, Inc.
 
-The software includes the open-source components listed below. Any use of the open-source components by you shall be governed by, and subject to, the terms and conditions of the applicable open-source licenses.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Except as this license expressly permits, you may not:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-* copy the software, in whole or in part; 
-* modify, correct, adapt, translate, enhance or otherwise prepare derivative works or improvements of the software; 
-* sell, sublicense, assign, distribute, publish, transfer or otherwise make available the software to any person or entity; 
-* remove, delete, efface, alter, obscure, translate, combine, supplement or otherwise change any trademarks, terms of the documentation, warranties, disclaimers, or intellectual property rights, or other symbols, notices, marks or serial numbers on or relating to any copy of the software or documentation; or
-use the software in any manner or for any purpose that infringes, misappropriates or otherwise violates any intellectual property right or other right of any person or entity, or that violates any applicable law;
-
-By using the software, you acknowledge and agree that:
-
-* the software and documentation are licensed, not sold, to you by Zimuth and you do not and will not have or acquire under or in connection with this license any ownership interest in the software or documentation, or in any related intellectual property rights; and
-* Zimuth will remain the sole and exclusive owner of all right, title and interest in and to the software and documentation, including all related intellectual property rights, subject only to the rights of third parties in open-source components and the limited license granted to you under this license; and
-
-Except for the limited rights and licenses expressly granted to you under this agreement, nothing in this license grants, by implication, waiver, estoppel or otherwise, to you or any third party any intellectual property rights or other right, title, or interest in or to any of the software or documentation.
-
-This license shall be automatically terminated and revoked if you exceed the scope or violate any terms and conditions of this license. 
-
-ALL LICENSED SOFTWARE, DOCUMENTATION AND OTHER PRODUCTS, INFORMATION, MATERIALS AND SERVICES PROVIDED BY ZIMUTH ARE PROVIDED HERE “AS IS.” ZIMUTH DISCLAIMS ALL WARRANTIES, WHETHER EXPRESS, IMPLIED, STATUTORY OR OTHER (INCLUDING ALL WARRANTIES ARISING FROM COURSE OF DEALING, USAGE OR TRADE PRACTICE), AND SPECIFICALLY DISCLAIMS ALL IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. WITHOUT LIMITING THE FOREGOING, ZIMUTH MAKES NO WARRANTY OF ANY KIND THAT THE LICENSED SOFTWARE OR DOCUMENTATION, OR ANY OTHER LICENSOR OR THIRD-PARTY GOODS, SERVICES, TECHNOLOGIES OR MATERIALS, WILL MEET YOUR REQUIREMENTS, OPERATE WITHOUT INTERRUPTION, ACHIEVE ANY INTENDED RESULT, BE COMPATIBLE OR WORK WITH ANY OTHER GOODS, SERVICES, TECHNOLOGIES OR MATERIALS (INCLUDING ANY SOFTWARE, HARDWARE, SYSTEM OR NETWORK) EXCEPT IF AND TO THE EXTENT EXPRESSLY SET FORTH IN THE DOCUMENTATION, OR BE SECURE, ACCURATE, COMPLETE, FREE OF HARMFUL CODE OR ERROR FREE. ALL OPEN-SOURCE COMPONENTS AND OTHER THIRD-PARTY MATERIALS ARE PROVIDED “AS IS” AND ANY REPRESENTATION OR WARRANTY OF OR CONCERNING ANY OF THEM IS STRICTLY BETWEEN LICENSEE AND THE THIRD-PARTY OWNER OR DISTRIBUTOR OF SUCH OPEN-SOURCE COMPONENTS AND THIRD-PARTY MATERIALS.
-
-IN NO EVENT WILL ZIMUTH BE LIABLE UNDER OR IN CONNECTION WITH THIS LICENSE OR ITS SUBJECT MATTER UNDER ANY LEGAL OR EQUITABLE THEORY, INCLUDING BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY AND OTHERWISE, FOR ANY CONSEQUENTIAL, INCIDENTAL, INDIRECT, EXEMPLARY, SPECIAL, ENHANCED OR PUNITIVE DAMAGES, IN EACH CASE REGARDLESS OF WHETHER SUCH PERSONS WERE ADVISED OF THE POSSIBILITY OF SUCH LOSSES OR DAMAGES OR SUCH LOSSES OR DAMAGES WERE OTHERWISE FORESEEABLE, AND NOTWITHSTANDING THE FAILURE OF ANY AGREED OR OTHER REMEDY OF ITS ESSENTIAL PURPOSE.
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,10 @@ defmodule ScoutApm.Mixfile do
       name: :scout_apm,
       files: ["lib", "priv", "mix.exs", "README*", "LICENSE*"],
       maintainers: ["Scout Team"],
-      licenses: ["Scout Software Agent License"],
+      # Hex requires SPDX identifiers; custom licenses use the SPDX
+      # LicenseRef- form, with the license text shipped in the package
+      # (LICENSE.md, included via :files above).
+      licenses: ["LicenseRef-Scout-Software-Agent-License"],
       links: %{
         "GitHub" => "https://github.com/scoutapp/scout_apm_elixir",
         "Docs" => "http://docs.scoutapm.com/elixir"

--- a/mix.exs
+++ b/mix.exs
@@ -63,10 +63,7 @@ defmodule ScoutApm.Mixfile do
       name: :scout_apm,
       files: ["lib", "priv", "mix.exs", "README*", "LICENSE*"],
       maintainers: ["Scout Team"],
-      # Hex requires SPDX identifiers; custom licenses use the SPDX
-      # LicenseRef- form, with the license text shipped in the package
-      # (LICENSE.md, included via :files above).
-      licenses: ["LicenseRef-Scout-Software-Agent-License"],
+      licenses: ["MIT"],
       links: %{
         "GitHub" => "https://github.com/scoutapp/scout_apm_elixir",
         "Docs" => "http://docs.scoutapm.com/elixir"


### PR DESCRIPTION
The v2.1.0-rc.1 release run failed at the publish step with a Hex.pm server-side validation error:

```
Validation error(s)
  meta:
    licenses: invalid license "Scout Software Agent License"
```

Hex requires `licenses:` entries to be valid [SPDX](https://spdx.org/licenses/) identifiers. Rather than just renaming the proprietary license to the SPDX `LicenseRef-` form (this PR's first commit), we're taking the opportunity to fix a nine-year-old inconsistency: the Scout **Ruby** and **Python** agents are both MIT, while the Elixir agent has carried the proprietary "Scout Software Agent License" since 2017. The proprietary text also forbade modification and derivative works — at odds with this being a public repository that accepts community contributions.

## Changes

- `LICENSE.md` → the MIT License (same Zimuth, Inc. copyright as the other agents)
- `mix.exs` → `licenses: ["MIT"]` (valid SPDX, so Hex publishes cleanly)
- CHANGELOG entry under 2.1.0

Also resolves the long-standing license-compatibility blocker: closes #122 (agent unusable in AGPL-licensed applications under the proprietary license).

## After merge

Re-tagging `v2.1.0-rc.1` on the merge commit re-runs the Release workflow and publishes the RC — master's mix.exs already carries `2.1.0-rc.1`, so the tag/version check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYHakZwWy43idn5Lz2Yrrp